### PR TITLE
Bumped Zip dependency due to a security update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -30,11 +30,11 @@
       },
       {
         "package": "Zip",
-        "repositoryURL": "https://github.com/marmelroy/Zip.git",
+        "repositoryURL": "https://github.com/marmelroy/Zip",
         "state": {
           "branch": null,
-          "revision": "67fa55813b9e7b3b9acee9c0ae501def28746d76",
-          "version": "2.1.2"
+          "revision": "bca30f6d6c7d37cbc4aa8f6b0002e281dcc36195",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.53.0"),
         .package(url: "https://github.com/apple/swift-crypto", from: "3.2.0"),
-        .package(url: "https://github.com/marmelroy/Zip", from: "2.1.2"),
+        .package(url: "https://github.com/marmelroy/Zip", revision: "bca30f6d6c7d37cbc4aa8f6b0002e281dcc36195"),
     ],
     targets: [
         .target(name: "Bagbutik-Core", dependencies: [


### PR DESCRIPTION
There's a [high-severity exploit on the Zip dependency](https://github.com/advisories/GHSA-g454-wj9r-jpg4) that was [fixed here](https://github.com/marmelroy/Zip/pull/252) - [Issue](https://github.com/marmelroy/Zip/issues/245).

This PR addresses the issue by setting the fix to the HEAD of the master branch when this PR was open simply because the Zip dependency has not been maintained for multiple years. I don't expect a new release of that framework to be published anytime soon.