### PR TITLE
Replace marmelroy/Zip module dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -27,15 +27,6 @@
           "revision": "fef156a6135e584985ed26713dd2e9ee41f952cb",
           "version": "0.53.0"
         }
-      },
-      {
-        "package": "Zip",
-        "repositoryURL": "https://github.com/marmelroy/Zip",
-        "state": {
-          "branch": null,
-          "revision": "bca30f6d6c7d37cbc4aa8f6b0002e281dcc36195",
-          "version": null
-        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.53.0"),
         .package(url: "https://github.com/apple/swift-crypto", from: "3.2.0"),
-        .package(url: "https://github.com/marmelroy/Zip", revision: "bca30f6d6c7d37cbc4aa8f6b0002e281dcc36195"),
     ],
     targets: [
         .target(name: "Bagbutik-Core", dependencies: [
@@ -89,8 +88,7 @@ let package = Package(
                 "BagbutikGenerator",
                 "BagbutikDocsCollector",
                 .target(name: "BagbutikPolyfill", condition: .when(platforms: [.linux])),
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                "Zip"
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]),
         // Internal targets
         .target(

--- a/Sources/BagbutikCLI/BagbutikCLI.swift
+++ b/Sources/BagbutikCLI/BagbutikCLI.swift
@@ -2,7 +2,6 @@ import ArgumentParser
 import BagbutikDocsCollector
 import BagbutikGenerator
 import Foundation
-import Zip
 #if canImport(FoundationNetworking)
 // Linux support
 import BagbutikPolyfill
@@ -112,7 +111,7 @@ struct BagbutikCLI: AsyncParsableCommand {
                 try FileManager.default.removeItem(at: zipFileURL)
             }
             try FileManager.default.moveItem(at: locationURL, to: zipFileURL)
-            try Zip.unzipFile(zipFileURL, destination: unzippedLocationURL, overwrite: true, password: nil)
+            try Process.unzip(file: zipFileURL, destination: unzippedLocationURL)
             let files = try FileManager.default.contentsOfDirectory(atPath: unzippedLocationURL.path)
             guard let specFileName = files.first(where: { $0.hasSuffix(".json") }) else { throw CLIError.malformedSpecZip }
             let unzippedSpecFileURL = unzippedLocationURL.appendingPathComponent(specFileName)

--- a/Sources/BagbutikCLI/Process+Unzip.swift
+++ b/Sources/BagbutikCLI/Process+Unzip.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension Process {
+    /// Decompress the zip file to the destination folder.
+    ///
+    /// - Parameters:
+    ///   - file: The file path of the zip file to be decompressed.
+    ///   - destination: The folder path that will receive the decompressed files.
+    ///
+    /// Creates a `bash` process that calls the `unzip` command allowing overwrites
+    /// and setting the destination path.
+    ///
+    /// Throws an error with `stderr` content in case the command fails.
+    static func unzip(file: URL, destination: URL) throws {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/bash")
+        task.arguments = [
+            "-c",
+            "`which unzip` -o '\(file.relativePath)' -d '\(destination.relativePath)'"
+        ]
+        
+        let errorPipe = Pipe()
+        task.standardError = errorPipe
+        
+        try task.run()
+        task.waitUntilExit()
+        
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if !errorData.isEmpty, let description = String(data: errorData, encoding: .utf8) {
+            throw ProcessError(description: description)
+        }
+    }
+    
+    private struct ProcessError: Error, CustomStringConvertible {
+        var description: String
+    }
+}


### PR DESCRIPTION
Solves issue #169 by removing the dependency `marmelroy/Zip` that is now considered `unstable` due to a security fix not being released.
Adds an extension to `Foundation.Process` that executes a bash process with the `unzip` command and throws an error with the `stderr` as description in case the shell command returns an error code >= 1