### PR TITLE
Encode dates in `RequestBody`s with ISO 8601

### DIFF
--- a/Sources/Bagbutik-Core/Service/RequestBody.swift
+++ b/Sources/Bagbutik-Core/Service/RequestBody.swift
@@ -9,6 +9,7 @@ public protocol RequestBody: Encodable {
 public extension RequestBody {
     var jsonData: Data {
         let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
         return try! encoder.encode(self)
     }
 }


### PR DESCRIPTION
We need to encode dates with ISO 8601 when sending them as part of request bodies.