### PR TITLE
Add `see` property to  ErrorLinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ On 12/1/23 some errors (with status code 409) has been observed, with no `detail
 In Apple's OpenAPI spec and documentation the `associatedErrors` is not mentioned in `meta` property (last checked 12/1/23).
 But it is observed when creating a `ReviewSubmissionItem` with an `AppStoreVersion` fails.
 
+#### **FB22529824**: App Store Connect API Spec is missing the "see" property on ErrorLinks
+
+* Submitted: April 17th, 2026.
+
+In the OpenAPI spec for the App Store Connect API, the `ErrorLinks` schema does not include a `see` property.
+
+However, the live API returns `errors[].links.see` on some `ErrorResponse.Errors` payloads.
+One observed case is a `403` error with code `FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED`, where `links.see` is set to `/business`.
+
 #### **FB16908301**: App Store Connect API Spec is missing list of possible "PurchaseRequirement" on AppEvent
 
 * Submitted: March 17th, 2025.

--- a/Sources/Bagbutik-Core/Models/ErrorLinks.swift
+++ b/Sources/Bagbutik-Core/Models/ErrorLinks.swift
@@ -3,24 +3,29 @@ import Foundation
 public struct ErrorLinks: Codable, Sendable {
     public var about: String?
     public var associated: Associated?
+    public var see: String?
 
     public init(about: String? = nil,
-                associated: Associated? = nil)
+                associated: Associated? = nil,
+                see: String? = nil)
     {
         self.about = about
         self.associated = associated
+        self.see = see
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AnyCodingKey.self)
         about = try container.decodeIfPresent(String.self, forKey: "about")
         associated = try container.decodeIfPresent(Associated.self, forKey: "associated")
+        see = try container.decodeIfPresent(String.self, forKey: "see")
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: AnyCodingKey.self)
         try container.encodeIfPresent(about, forKey: "about")
         try container.encodeIfPresent(associated, forKey: "associated")
+        try container.encodeIfPresent(see, forKey: "see")
     }
 
     public enum Associated: Codable, Sendable {

--- a/Sources/BagbutikSpecDecoder/Spec.swift
+++ b/Sources/BagbutikSpecDecoder/Spec.swift
@@ -224,6 +224,16 @@ public struct Spec: Decodable {
             }
         }
 
+        // FB22529824: Add `see` to ErrorLinks
+        // Some App Store Connect errors include a `links.see` URL for resolving the issue,
+        // but Apple's OpenAPI spec currently omits that property from ErrorLinks.
+        if case .object(var errorLinksSchema) = components.schemas["ErrorLinks"],
+           errorLinksSchema.properties["see"] == nil {
+            errorLinksSchema.properties["see"] = .init(type: .simple(.string()))
+            components.schemas["ErrorLinks"] = .object(errorLinksSchema)
+            addPatchedSchema(.object(errorLinksSchema), location: .topLevel(schemaName: "ErrorLinks"))
+        }
+
         // Fix up the names of the sub schemas of ErrorResponse.Errors
         if components.schemas["ErrorResponse"] != nil {
             guard case .object(var errorResponseSchema) = components.schemas["ErrorResponse"],

--- a/Tests/Bagbutik-CoreTests/ErrorLinksTests.swift
+++ b/Tests/Bagbutik-CoreTests/ErrorLinksTests.swift
@@ -1,0 +1,25 @@
+import Bagbutik_Core
+import XCTest
+
+final class ErrorLinksTests: XCTestCase {
+    func testDecodeErrorResponseWithSeeLink() throws {
+        let json = """
+        {
+          "errors": [
+            {
+              "status": "403",
+              "code": "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED",
+              "title": "A required agreement is missing or has expired.",
+              "links": {
+                "see": "/business"
+              }
+            }
+          ]
+        }
+        """
+
+        let response = try JSONDecoder().decode(ErrorResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.errors?.first?.links?.see, "/business")
+    }
+}

--- a/Tests/BagbutikSpecDecoderTests/SpecTests.swift
+++ b/Tests/BagbutikSpecDecoderTests/SpecTests.swift
@@ -668,6 +668,19 @@ final class SpecTests: XCTestCase {
                             }
                         }
                     },
+                    "ErrorLinks" : {
+                        "type" : "object",
+                        "properties" : {
+                            "about" : {
+                                "type" : "string",
+                                "format" : "uri-reference"
+                            },
+                            "associated" : {
+                                "type" : "string",
+                                "format" : "uri-reference"
+                            }
+                        }
+                    },
                     "AgeRatingDeclarationUpdateRequest" : {
                         "type" : "object",
                         "title" : "AgeRatingDeclarationUpdateRequest",
@@ -829,6 +842,15 @@ final class SpecTests: XCTestCase {
         XCTAssertEqual(errorSchemaRef, "Errors")
         XCTAssertTrue(spec.patchedSchemasWithLocation.contains {
             $0.location == .nestedProperty(rootSchemaName: "ErrorResponse", propertyPath: ["errors"])
+        })
+        guard case .object(let errorLinksSchema) = spec.components.schemas["ErrorLinks"],
+              let seeProperty = errorLinksSchema.properties["see"],
+              case .simple(let seeType) = seeProperty.type else {
+            XCTFail(); return
+        }
+        XCTAssertEqual(seeType, .string())
+        XCTAssertTrue(spec.patchedSchemasWithLocation.contains {
+            $0.location == .topLevel(schemaName: "ErrorLinks")
         })
         guard let resolvedErrorsSchema = spec.resolveSchema(
             at: .nestedProperty(rootSchemaName: "ErrorResponse", propertyPath: ["errors"])

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 ignore:
+  - "Tests"
   - "Sources/Bagbutik-Core/Models"
   - "Sources/Bagbutik-Core/AnyCodingKey.swift"
   - "Sources/Bagbutik-Models/AppStore"


### PR DESCRIPTION
## Summary
- patch the spec decoder so generated models include `see` on `ErrorLinks`
- register feedback FB22529824 in the README and cover the change with focused tests

## Testing
- swift test --filter ErrorLinksTests
- swift test --filter SpecTests