### PR TITLE
Handle empty documentation content sections

### DIFF
--- a/Sources/BagbutikDocsCollector/Models/Documentation.swift
+++ b/Sources/BagbutikDocsCollector/Models/Documentation.swift
@@ -396,10 +396,11 @@ public enum Documentation: Codable, Equatable, Sendable {
                 self = .properties(properties)
             } else if kind == "content" {
                 let contents = try container
-                    .decode([Content].self, forKey: .content)
-                    .filter { $0.type != "heading" }
-                guard !contents.isEmpty else {
-                    throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Content section of kind '\(kind)' has no content")
+                    .decodeIfPresent([Content].self, forKey: .content)?
+                    .filter { $0.type != "heading" } ?? []
+                if contents.isEmpty {
+                    self = .unused
+                    return
                 }
                 self = .discussion(contents)
             } else if kind == "restParameters" {

--- a/Tests/BagbutikDocsCollectorTests/DocumentationTests.swift
+++ b/Tests/BagbutikDocsCollectorTests/DocumentationTests.swift
@@ -169,6 +169,71 @@ class DocumentationTests: XCTestCase {
         XCTAssertEqual(enumDocumentation.cases["MAC_OS"], "[Related Article](https://developer.apple.com/documentation/appstoreconnectapi/related-article)")
     }
 
+    func testDecodeEnumDocumentationIgnoresEmptyContentSections() throws {
+        let data = """
+        {
+            "identifier": {
+                "url": "doc://com.apple.appstoreconnectapi/documentation/AppStoreConnectAPI/subscriptionoffermode"
+            },
+            "hierarchy": {
+                "paths": [[]]
+            },
+            "metadata": {
+                "title": "SubscriptionOfferMode",
+                "symbolKind": "tdef"
+            },
+            "primaryContentSections": [
+                {
+                    "kind": "possibleValues",
+                    "values": [
+                        {
+                            "name": "PAY_AS_YOU_GO",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "inlineContent": [
+                                        {
+                                            "type": "text",
+                                            "text": "Pay as you go."
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "content",
+                    "content": []
+                },
+                {
+                    "kind": "content",
+                    "content": [
+                        {
+                            "type": "heading",
+                            "inlineContent": [
+                                {
+                                    "type": "text",
+                                    "text": "Discussion"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let documentation = try JSONDecoder().decode(Documentation.self, from: data)
+
+        guard case .enum(let enumDocumentation) = documentation else {
+            return XCTFail("Expected enum documentation")
+        }
+
+        XCTAssertNil(enumDocumentation.discussion)
+        XCTAssertEqual(enumDocumentation.cases["PAY_AS_YOU_GO"], "Pay as you go.")
+    }
+
     func testDecodeObjectDocumentationCollectsSubDocumentationIds() throws {
         let data = """
         {


### PR DESCRIPTION
## Summary
- Treat Apple `kind: "content"` sections with no non heading content as unused instead of failing decoding
- Add a regression test covering `SubscriptionOfferMode` style payloads with empty or heading only discussion sections

## Testing
- `swift test --filter DocumentationTests`