### PR TITLE
Update GitHub Actions to Swift 6.3 and Xcode 26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-apple:
     name: Build and Test (macOS)
-    runs-on: macos-latest
+    runs-on: macos-26
     permissions:
       contents: read
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: read
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
     - name: Print Xcode & Swift Version
@@ -63,7 +65,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        swift: ["5.10", "6.0", "6.1", "6.2"]
+        swift: ["5.10", "6.0", "6.1", "6.2", "6.3"]
     steps:
     - uses: vapor/swiftly-action@v0.2
       with:
@@ -72,7 +74,7 @@ jobs:
     - name: Test
       run: swift test -v
   build-android:
-    name: Build and Test (Android) - Swift 6.1
+    name: Build and Test (Android) - Swift 6.3
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -90,4 +92,4 @@ jobs:
         swap-storage: true
     - uses: skiptools/swift-android-action@v2
       with:
-        swift-version: 6.1
+        swift-version: 6.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and Deploy
-    runs-on: macos-latest
+    runs-on: macos-26
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and Deploy
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
     - name: Generate Documentation for Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-xcframeworks:
     name: Build and Attach XCFramework Asset
-    runs-on: macos-latest
+    runs-on: macos-26
     permissions:
       contents: write
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
     env:
+      DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Updated macOS workflows to use `Xcode_26.4.app` via `DEVELOPER_DIR`
- Added Swift `6.3` to the Linux test matrix
- Bumped the Android workflow to Swift `6.3`

## Testing
- Not run (not requested)