### PR TITLE
Use discriminator for decoding responses

### DIFF
--- a/Sources/Bagbutik-AppStore/Models/AppClipAdvancedExperienceResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipAdvancedExperienceResponse.swift
@@ -72,18 +72,20 @@ public struct AppClipAdvancedExperienceResponse: Codable, Sendable {
         case appClipAdvancedExperienceLocalization(AppClipAdvancedExperienceLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appClip = try? AppClip(from: decoder) {
-                self = .appClip(appClip)
-            } else if let appClipAdvancedExperienceImage = try? AppClipAdvancedExperienceImage(from: decoder) {
-                self = .appClipAdvancedExperienceImage(appClipAdvancedExperienceImage)
-            } else if let appClipAdvancedExperienceLocalization = try? AppClipAdvancedExperienceLocalization(from: decoder) {
-                self = .appClipAdvancedExperienceLocalization(appClipAdvancedExperienceLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appClips":
+                self = .appClip(try AppClip(from: decoder))
+            case "appClipAdvancedExperienceImages":
+                self = .appClipAdvancedExperienceImage(try AppClipAdvancedExperienceImage(from: decoder))
+            case "appClipAdvancedExperienceLocalizations":
+                self = .appClipAdvancedExperienceLocalization(try AppClipAdvancedExperienceLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppClipAdvancedExperiencesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipAdvancedExperiencesResponse.swift
@@ -80,18 +80,20 @@ public struct AppClipAdvancedExperiencesResponse: Codable, Sendable, PagedRespon
         case appClipAdvancedExperienceLocalization(AppClipAdvancedExperienceLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appClip = try? AppClip(from: decoder) {
-                self = .appClip(appClip)
-            } else if let appClipAdvancedExperienceImage = try? AppClipAdvancedExperienceImage(from: decoder) {
-                self = .appClipAdvancedExperienceImage(appClipAdvancedExperienceImage)
-            } else if let appClipAdvancedExperienceLocalization = try? AppClipAdvancedExperienceLocalization(from: decoder) {
-                self = .appClipAdvancedExperienceLocalization(appClipAdvancedExperienceLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appClips":
+                self = .appClip(try AppClip(from: decoder))
+            case "appClipAdvancedExperienceImages":
+                self = .appClipAdvancedExperienceImage(try AppClipAdvancedExperienceImage(from: decoder))
+            case "appClipAdvancedExperienceLocalizations":
+                self = .appClipAdvancedExperienceLocalization(try AppClipAdvancedExperienceLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperienceLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperienceLocalizationResponse.swift
@@ -59,16 +59,18 @@ public struct AppClipDefaultExperienceLocalizationResponse: Codable, Sendable {
         case appClipHeaderImage(AppClipHeaderImage)
 
         public init(from decoder: Decoder) throws {
-            if let appClipDefaultExperience = try? AppClipDefaultExperience(from: decoder) {
-                self = .appClipDefaultExperience(appClipDefaultExperience)
-            } else if let appClipHeaderImage = try? AppClipHeaderImage(from: decoder) {
-                self = .appClipHeaderImage(appClipHeaderImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appClipDefaultExperiences":
+                self = .appClipDefaultExperience(try AppClipDefaultExperience(from: decoder))
+            case "appClipHeaderImages":
+                self = .appClipHeaderImage(try AppClipHeaderImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperienceLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperienceLocalizationsResponse.swift
@@ -67,16 +67,18 @@ public struct AppClipDefaultExperienceLocalizationsResponse: Codable, Sendable, 
         case appClipHeaderImage(AppClipHeaderImage)
 
         public init(from decoder: Decoder) throws {
-            if let appClipDefaultExperience = try? AppClipDefaultExperience(from: decoder) {
-                self = .appClipDefaultExperience(appClipDefaultExperience)
-            } else if let appClipHeaderImage = try? AppClipHeaderImage(from: decoder) {
-                self = .appClipHeaderImage(appClipHeaderImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appClipDefaultExperiences":
+                self = .appClipDefaultExperience(try AppClipDefaultExperience(from: decoder))
+            case "appClipHeaderImages":
+                self = .appClipHeaderImage(try AppClipHeaderImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperienceResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperienceResponse.swift
@@ -80,20 +80,22 @@ public struct AppClipDefaultExperienceResponse: Codable, Sendable {
         case appStoreVersion(AppStoreVersion)
 
         public init(from decoder: Decoder) throws {
-            if let appClip = try? AppClip(from: decoder) {
-                self = .appClip(appClip)
-            } else if let appClipAppStoreReviewDetail = try? AppClipAppStoreReviewDetail(from: decoder) {
-                self = .appClipAppStoreReviewDetail(appClipAppStoreReviewDetail)
-            } else if let appClipDefaultExperienceLocalization = try? AppClipDefaultExperienceLocalization(from: decoder) {
-                self = .appClipDefaultExperienceLocalization(appClipDefaultExperienceLocalization)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appClips":
+                self = .appClip(try AppClip(from: decoder))
+            case "appClipAppStoreReviewDetails":
+                self = .appClipAppStoreReviewDetail(try AppClipAppStoreReviewDetail(from: decoder))
+            case "appClipDefaultExperienceLocalizations":
+                self = .appClipDefaultExperienceLocalization(try AppClipDefaultExperienceLocalization(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperiencesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipDefaultExperiencesResponse.swift
@@ -88,20 +88,22 @@ public struct AppClipDefaultExperiencesResponse: Codable, Sendable, PagedRespons
         case appStoreVersion(AppStoreVersion)
 
         public init(from decoder: Decoder) throws {
-            if let appClip = try? AppClip(from: decoder) {
-                self = .appClip(appClip)
-            } else if let appClipAppStoreReviewDetail = try? AppClipAppStoreReviewDetail(from: decoder) {
-                self = .appClipAppStoreReviewDetail(appClipAppStoreReviewDetail)
-            } else if let appClipDefaultExperienceLocalization = try? AppClipDefaultExperienceLocalization(from: decoder) {
-                self = .appClipDefaultExperienceLocalization(appClipDefaultExperienceLocalization)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appClips":
+                self = .appClip(try AppClip(from: decoder))
+            case "appClipAppStoreReviewDetails":
+                self = .appClipAppStoreReviewDetail(try AppClipAppStoreReviewDetail(from: decoder))
+            case "appClipDefaultExperienceLocalizations":
+                self = .appClipDefaultExperienceLocalization(try AppClipDefaultExperienceLocalization(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppClipResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipResponse.swift
@@ -64,16 +64,18 @@ public struct AppClipResponse: Codable, Sendable {
         case appClipDefaultExperience(AppClipDefaultExperience)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appClipDefaultExperience = try? AppClipDefaultExperience(from: decoder) {
-                self = .appClipDefaultExperience(appClipDefaultExperience)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appClipDefaultExperiences":
+                self = .appClipDefaultExperience(try AppClipDefaultExperience(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppClipsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppClipsResponse.swift
@@ -72,16 +72,18 @@ public struct AppClipsResponse: Codable, Sendable, PagedResponse {
         case appClipDefaultExperience(AppClipDefaultExperience)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appClipDefaultExperience = try? AppClipDefaultExperience(from: decoder) {
-                self = .appClipDefaultExperience(appClipDefaultExperience)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appClipDefaultExperiences":
+                self = .appClipDefaultExperience(try AppClipDefaultExperience(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationResponse.swift
@@ -87,20 +87,22 @@ public struct AppCustomProductPageLocalizationResponse: Codable, Sendable {
         case appScreenshotSet(AppScreenshotSet)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageVersion = try? AppCustomProductPageVersion(from: decoder) {
-                self = .appCustomProductPageVersion(appCustomProductPageVersion)
-            } else if let appKeyword = try? AppKeyword(from: decoder) {
-                self = .appKeyword(appKeyword)
-            } else if let appPreviewSet = try? AppPreviewSet(from: decoder) {
-                self = .appPreviewSet(appPreviewSet)
-            } else if let appScreenshotSet = try? AppScreenshotSet(from: decoder) {
-                self = .appScreenshotSet(appScreenshotSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageVersions":
+                self = .appCustomProductPageVersion(try AppCustomProductPageVersion(from: decoder))
+            case "appKeywords":
+                self = .appKeyword(try AppKeyword(from: decoder))
+            case "appPreviewSets":
+                self = .appPreviewSet(try AppPreviewSet(from: decoder))
+            case "appScreenshotSets":
+                self = .appScreenshotSet(try AppScreenshotSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationsResponse.swift
@@ -94,20 +94,22 @@ public struct AppCustomProductPageLocalizationsResponse: Codable, Sendable, Page
         case appScreenshotSet(AppScreenshotSet)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageVersion = try? AppCustomProductPageVersion(from: decoder) {
-                self = .appCustomProductPageVersion(appCustomProductPageVersion)
-            } else if let appKeyword = try? AppKeyword(from: decoder) {
-                self = .appKeyword(appKeyword)
-            } else if let appPreviewSet = try? AppPreviewSet(from: decoder) {
-                self = .appPreviewSet(appPreviewSet)
-            } else if let appScreenshotSet = try? AppScreenshotSet(from: decoder) {
-                self = .appScreenshotSet(appScreenshotSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageVersions":
+                self = .appCustomProductPageVersion(try AppCustomProductPageVersion(from: decoder))
+            case "appKeywords":
+                self = .appKeyword(try AppKeyword(from: decoder))
+            case "appPreviewSets":
+                self = .appPreviewSet(try AppPreviewSet(from: decoder))
+            case "appScreenshotSets":
+                self = .appScreenshotSet(try AppScreenshotSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPageResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPageResponse.swift
@@ -62,18 +62,20 @@ public struct AppCustomProductPageResponse: Codable, Sendable {
         case appCustomProductPageVersion(AppCustomProductPageVersion)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else if let appCustomProductPageVersion = try? AppCustomProductPageVersion(from: decoder) {
-                self = .appCustomProductPageVersion(appCustomProductPageVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            case "appCustomProductPageVersions":
+                self = .appCustomProductPageVersion(try AppCustomProductPageVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPageVersionResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPageVersionResponse.swift
@@ -61,16 +61,18 @@ public struct AppCustomProductPageVersionResponse: Codable, Sendable {
         case appCustomProductPageLocalization(AppCustomProductPageLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPage = try? AppCustomProductPage(from: decoder) {
-                self = .appCustomProductPage(appCustomProductPage)
-            } else if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPages":
+                self = .appCustomProductPage(try AppCustomProductPage(from: decoder))
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPageVersionsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPageVersionsResponse.swift
@@ -68,16 +68,18 @@ public struct AppCustomProductPageVersionsResponse: Codable, Sendable, PagedResp
         case appCustomProductPageLocalization(AppCustomProductPageLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPage = try? AppCustomProductPage(from: decoder) {
-                self = .appCustomProductPage(appCustomProductPage)
-            } else if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPages":
+                self = .appCustomProductPage(try AppCustomProductPage(from: decoder))
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPagesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPagesResponse.swift
@@ -69,18 +69,20 @@ public struct AppCustomProductPagesResponse: Codable, Sendable, PagedResponse {
         case appCustomProductPageVersion(AppCustomProductPageVersion)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else if let appCustomProductPageVersion = try? AppCustomProductPageVersion(from: decoder) {
-                self = .appCustomProductPageVersion(appCustomProductPageVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            case "appCustomProductPageVersions":
+                self = .appCustomProductPageVersion(try AppCustomProductPageVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationResponse.swift
@@ -52,18 +52,20 @@ public struct AppEncryptionDeclarationResponse: Codable, Sendable {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appEncryptionDeclarationDocument = try? AppEncryptionDeclarationDocument(from: decoder) {
-                self = .appEncryptionDeclarationDocument(appEncryptionDeclarationDocument)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appEncryptionDeclarationDocuments":
+                self = .appEncryptionDeclarationDocument(try AppEncryptionDeclarationDocument(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationsResponse.swift
@@ -60,18 +60,20 @@ public struct AppEncryptionDeclarationsResponse: Codable, Sendable, PagedRespons
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appEncryptionDeclarationDocument = try? AppEncryptionDeclarationDocument(from: decoder) {
-                self = .appEncryptionDeclarationDocument(appEncryptionDeclarationDocument)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appEncryptionDeclarationDocuments":
+                self = .appEncryptionDeclarationDocument(try AppEncryptionDeclarationDocument(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppEventLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEventLocalizationResponse.swift
@@ -67,18 +67,20 @@ public struct AppEventLocalizationResponse: Codable, Sendable {
         case appEventVideoClip(AppEventVideoClip)
 
         public init(from decoder: Decoder) throws {
-            if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let appEventScreenshot = try? AppEventScreenshot(from: decoder) {
-                self = .appEventScreenshot(appEventScreenshot)
-            } else if let appEventVideoClip = try? AppEventVideoClip(from: decoder) {
-                self = .appEventVideoClip(appEventVideoClip)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "appEventScreenshots":
+                self = .appEventScreenshot(try AppEventScreenshot(from: decoder))
+            case "appEventVideoClips":
+                self = .appEventVideoClip(try AppEventVideoClip(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppEventLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEventLocalizationsResponse.swift
@@ -74,18 +74,20 @@ public struct AppEventLocalizationsResponse: Codable, Sendable, PagedResponse {
         case appEventVideoClip(AppEventVideoClip)
 
         public init(from decoder: Decoder) throws {
-            if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let appEventScreenshot = try? AppEventScreenshot(from: decoder) {
-                self = .appEventScreenshot(appEventScreenshot)
-            } else if let appEventVideoClip = try? AppEventVideoClip(from: decoder) {
-                self = .appEventVideoClip(appEventVideoClip)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "appEventScreenshots":
+                self = .appEventScreenshot(try AppEventScreenshot(from: decoder))
+            case "appEventVideoClips":
+                self = .appEventVideoClip(try AppEventVideoClip(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppInfoResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppInfoResponse.swift
@@ -114,20 +114,22 @@ public struct AppInfoResponse: Codable, Sendable {
         case appInfoLocalization(AppInfoLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let ageRatingDeclaration = try? AgeRatingDeclaration(from: decoder) {
-                self = .ageRatingDeclaration(ageRatingDeclaration)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appCategory = try? AppCategory(from: decoder) {
-                self = .appCategory(appCategory)
-            } else if let appInfoLocalization = try? AppInfoLocalization(from: decoder) {
-                self = .appInfoLocalization(appInfoLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "ageRatingDeclarations":
+                self = .ageRatingDeclaration(try AgeRatingDeclaration(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appCategories":
+                self = .appCategory(try AppCategory(from: decoder))
+            case "appInfoLocalizations":
+                self = .appInfoLocalization(try AppInfoLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppInfosResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppInfosResponse.swift
@@ -122,20 +122,22 @@ public struct AppInfosResponse: Codable, Sendable, PagedResponse {
         case appInfoLocalization(AppInfoLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let ageRatingDeclaration = try? AgeRatingDeclaration(from: decoder) {
-                self = .ageRatingDeclaration(ageRatingDeclaration)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appCategory = try? AppCategory(from: decoder) {
-                self = .appCategory(appCategory)
-            } else if let appInfoLocalization = try? AppInfoLocalization(from: decoder) {
-                self = .appInfoLocalization(appInfoLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "ageRatingDeclarations":
+                self = .ageRatingDeclaration(try AgeRatingDeclaration(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appCategories":
+                self = .appCategory(try AppCategory(from: decoder))
+            case "appInfoLocalizations":
+                self = .appInfoLocalization(try AppInfoLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppPreviewSetResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppPreviewSetResponse.swift
@@ -77,20 +77,22 @@ public struct AppPreviewSetResponse: Codable, Sendable {
         case appStoreVersionLocalization(AppStoreVersionLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else if let appPreview = try? AppPreview(from: decoder) {
-                self = .appPreview(appPreview)
-            } else if let appStoreVersionExperimentTreatmentLocalization = try? AppStoreVersionExperimentTreatmentLocalization(from: decoder) {
-                self = .appStoreVersionExperimentTreatmentLocalization(appStoreVersionExperimentTreatmentLocalization)
-            } else if let appStoreVersionLocalization = try? AppStoreVersionLocalization(from: decoder) {
-                self = .appStoreVersionLocalization(appStoreVersionLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            case "appPreviews":
+                self = .appPreview(try AppPreview(from: decoder))
+            case "appStoreVersionExperimentTreatmentLocalizations":
+                self = .appStoreVersionExperimentTreatmentLocalization(try AppStoreVersionExperimentTreatmentLocalization(from: decoder))
+            case "appStoreVersionLocalizations":
+                self = .appStoreVersionLocalization(try AppStoreVersionLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppPreviewSetsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppPreviewSetsResponse.swift
@@ -84,20 +84,22 @@ public struct AppPreviewSetsResponse: Codable, Sendable, PagedResponse {
         case appStoreVersionLocalization(AppStoreVersionLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else if let appPreview = try? AppPreview(from: decoder) {
-                self = .appPreview(appPreview)
-            } else if let appStoreVersionExperimentTreatmentLocalization = try? AppStoreVersionExperimentTreatmentLocalization(from: decoder) {
-                self = .appStoreVersionExperimentTreatmentLocalization(appStoreVersionExperimentTreatmentLocalization)
-            } else if let appStoreVersionLocalization = try? AppStoreVersionLocalization(from: decoder) {
-                self = .appStoreVersionLocalization(appStoreVersionLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            case "appPreviews":
+                self = .appPreview(try AppPreview(from: decoder))
+            case "appStoreVersionExperimentTreatmentLocalizations":
+                self = .appStoreVersionExperimentTreatmentLocalization(try AppStoreVersionExperimentTreatmentLocalization(from: decoder))
+            case "appStoreVersionLocalizations":
+                self = .appStoreVersionLocalization(try AppStoreVersionLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppPricePointV3Response.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppPricePointV3Response.swift
@@ -49,16 +49,18 @@ public struct AppPricePointV3Response: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppPricePointsV3Response.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppPricePointsV3Response.swift
@@ -56,16 +56,18 @@ public struct AppPricePointsV3Response: Codable, Sendable, PagedResponse {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppPriceScheduleResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppPriceScheduleResponse.swift
@@ -74,18 +74,20 @@ public struct AppPriceScheduleResponse: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appPriceV2 = try? AppPriceV2(from: decoder) {
-                self = .appPriceV2(appPriceV2)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appPrices":
+                self = .appPriceV2(try AppPriceV2(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppPricesV2Response.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppPricesV2Response.swift
@@ -56,16 +56,18 @@ public struct AppPricesV2Response: Codable, Sendable, PagedResponse {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let appPricePointV3 = try? AppPricePointV3(from: decoder) {
-                self = .appPricePointV3(appPricePointV3)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appPricePoints":
+                self = .appPricePointV3(try AppPricePointV3(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppResponse.swift
@@ -319,60 +319,62 @@ public struct AppResponse: Codable, Sendable {
         case subscriptionGroup(SubscriptionGroup)
 
         public init(from decoder: Decoder) throws {
-            if let androidToIosAppMappingDetail = try? AndroidToIosAppMappingDetail(from: decoder) {
-                self = .androidToIosAppMappingDetail(androidToIosAppMappingDetail)
-            } else if let appClip = try? AppClip(from: decoder) {
-                self = .appClip(appClip)
-            } else if let appCustomProductPage = try? AppCustomProductPage(from: decoder) {
-                self = .appCustomProductPage(appCustomProductPage)
-            } else if let appEncryptionDeclaration = try? AppEncryptionDeclaration(from: decoder) {
-                self = .appEncryptionDeclaration(appEncryptionDeclaration)
-            } else if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let appInfo = try? AppInfo(from: decoder) {
-                self = .appInfo(appInfo)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperimentV2 = try? AppStoreVersionExperimentV2(from: decoder) {
-                self = .appStoreVersionExperimentV2(appStoreVersionExperimentV2)
-            } else if let betaAppLocalization = try? BetaAppLocalization(from: decoder) {
-                self = .betaAppLocalization(betaAppLocalization)
-            } else if let betaAppReviewDetail = try? BetaAppReviewDetail(from: decoder) {
-                self = .betaAppReviewDetail(betaAppReviewDetail)
-            } else if let betaGroup = try? BetaGroup(from: decoder) {
-                self = .betaGroup(betaGroup)
-            } else if let betaLicenseAgreement = try? BetaLicenseAgreement(from: decoder) {
-                self = .betaLicenseAgreement(betaLicenseAgreement)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let buildIcon = try? BuildIcon(from: decoder) {
-                self = .buildIcon(buildIcon)
-            } else if let ciProduct = try? CiProduct(from: decoder) {
-                self = .ciProduct(ciProduct)
-            } else if let endUserLicenseAgreement = try? EndUserLicenseAgreement(from: decoder) {
-                self = .endUserLicenseAgreement(endUserLicenseAgreement)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterEnabledVersion = try? GameCenterEnabledVersion(from: decoder) {
-                self = .gameCenterEnabledVersion(gameCenterEnabledVersion)
-            } else if let inAppPurchase = try? InAppPurchase(from: decoder) {
-                self = .inAppPurchase(inAppPurchase)
-            } else if let prereleaseVersion = try? PrereleaseVersion(from: decoder) {
-                self = .prereleaseVersion(prereleaseVersion)
-            } else if let promotedPurchase = try? PromotedPurchase(from: decoder) {
-                self = .promotedPurchase(promotedPurchase)
-            } else if let reviewSubmission = try? ReviewSubmission(from: decoder) {
-                self = .reviewSubmission(reviewSubmission)
-            } else if let subscriptionGracePeriod = try? SubscriptionGracePeriod(from: decoder) {
-                self = .subscriptionGracePeriod(subscriptionGracePeriod)
-            } else if let subscriptionGroup = try? SubscriptionGroup(from: decoder) {
-                self = .subscriptionGroup(subscriptionGroup)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "androidToIosAppMappingDetails":
+                self = .androidToIosAppMappingDetail(try AndroidToIosAppMappingDetail(from: decoder))
+            case "appClips":
+                self = .appClip(try AppClip(from: decoder))
+            case "appCustomProductPages":
+                self = .appCustomProductPage(try AppCustomProductPage(from: decoder))
+            case "appEncryptionDeclarations":
+                self = .appEncryptionDeclaration(try AppEncryptionDeclaration(from: decoder))
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "appInfos":
+                self = .appInfo(try AppInfo(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperimentV2(try AppStoreVersionExperimentV2(from: decoder))
+            case "betaAppLocalizations":
+                self = .betaAppLocalization(try BetaAppLocalization(from: decoder))
+            case "betaAppReviewDetails":
+                self = .betaAppReviewDetail(try BetaAppReviewDetail(from: decoder))
+            case "betaGroups":
+                self = .betaGroup(try BetaGroup(from: decoder))
+            case "betaLicenseAgreements":
+                self = .betaLicenseAgreement(try BetaLicenseAgreement(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "buildIcons":
+                self = .buildIcon(try BuildIcon(from: decoder))
+            case "ciProducts":
+                self = .ciProduct(try CiProduct(from: decoder))
+            case "endUserLicenseAgreements":
+                self = .endUserLicenseAgreement(try EndUserLicenseAgreement(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterEnabledVersions":
+                self = .gameCenterEnabledVersion(try GameCenterEnabledVersion(from: decoder))
+            case "inAppPurchases":
+                self = .inAppPurchase(try InAppPurchase(from: decoder))
+            case "preReleaseVersions":
+                self = .prereleaseVersion(try PrereleaseVersion(from: decoder))
+            case "promotedPurchases":
+                self = .promotedPurchase(try PromotedPurchase(from: decoder))
+            case "reviewSubmissions":
+                self = .reviewSubmission(try ReviewSubmission(from: decoder))
+            case "subscriptionGracePeriods":
+                self = .subscriptionGracePeriod(try SubscriptionGracePeriod(from: decoder))
+            case "subscriptionGroups":
+                self = .subscriptionGroup(try SubscriptionGroup(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppScreenshotSetResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppScreenshotSetResponse.swift
@@ -77,20 +77,22 @@ public struct AppScreenshotSetResponse: Codable, Sendable {
         case appStoreVersionLocalization(AppStoreVersionLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else if let appScreenshot = try? AppScreenshot(from: decoder) {
-                self = .appScreenshot(appScreenshot)
-            } else if let appStoreVersionExperimentTreatmentLocalization = try? AppStoreVersionExperimentTreatmentLocalization(from: decoder) {
-                self = .appStoreVersionExperimentTreatmentLocalization(appStoreVersionExperimentTreatmentLocalization)
-            } else if let appStoreVersionLocalization = try? AppStoreVersionLocalization(from: decoder) {
-                self = .appStoreVersionLocalization(appStoreVersionLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            case "appScreenshots":
+                self = .appScreenshot(try AppScreenshot(from: decoder))
+            case "appStoreVersionExperimentTreatmentLocalizations":
+                self = .appStoreVersionExperimentTreatmentLocalization(try AppStoreVersionExperimentTreatmentLocalization(from: decoder))
+            case "appStoreVersionLocalizations":
+                self = .appStoreVersionLocalization(try AppStoreVersionLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppScreenshotSetsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppScreenshotSetsResponse.swift
@@ -84,20 +84,22 @@ public struct AppScreenshotSetsResponse: Codable, Sendable, PagedResponse {
         case appStoreVersionLocalization(AppStoreVersionLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageLocalization = try? AppCustomProductPageLocalization(from: decoder) {
-                self = .appCustomProductPageLocalization(appCustomProductPageLocalization)
-            } else if let appScreenshot = try? AppScreenshot(from: decoder) {
-                self = .appScreenshot(appScreenshot)
-            } else if let appStoreVersionExperimentTreatmentLocalization = try? AppStoreVersionExperimentTreatmentLocalization(from: decoder) {
-                self = .appStoreVersionExperimentTreatmentLocalization(appStoreVersionExperimentTreatmentLocalization)
-            } else if let appStoreVersionLocalization = try? AppStoreVersionLocalization(from: decoder) {
-                self = .appStoreVersionLocalization(appStoreVersionLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageLocalizations":
+                self = .appCustomProductPageLocalization(try AppCustomProductPageLocalization(from: decoder))
+            case "appScreenshots":
+                self = .appScreenshot(try AppScreenshot(from: decoder))
+            case "appStoreVersionExperimentTreatmentLocalizations":
+                self = .appStoreVersionExperimentTreatmentLocalization(try AppStoreVersionExperimentTreatmentLocalization(from: decoder))
+            case "appStoreVersionLocalizations":
+                self = .appStoreVersionLocalization(try AppStoreVersionLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreReviewDetailResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreReviewDetailResponse.swift
@@ -61,16 +61,18 @@ public struct AppStoreReviewDetailResponse: Codable, Sendable {
         case appStoreVersion(AppStoreVersion)
 
         public init(from decoder: Decoder) throws {
-            if let appStoreReviewAttachment = try? AppStoreReviewAttachment(from: decoder) {
-                self = .appStoreReviewAttachment(appStoreReviewAttachment)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appStoreReviewAttachments":
+                self = .appStoreReviewAttachment(try AppStoreReviewAttachment(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentResponse.swift
@@ -54,16 +54,18 @@ public struct AppStoreVersionExperimentResponse: Codable, Sendable {
         case appStoreVersionExperimentTreatment(AppStoreVersionExperimentTreatment)
 
         public init(from decoder: Decoder) throws {
-            if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperimentTreatment = try? AppStoreVersionExperimentTreatment(from: decoder) {
-                self = .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperimentTreatments":
+                self = .appStoreVersionExperimentTreatment(try AppStoreVersionExperimentTreatment(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationResponse.swift
@@ -74,18 +74,20 @@ public struct AppStoreVersionExperimentTreatmentLocalizationResponse: Codable, S
         case appStoreVersionExperimentTreatment(AppStoreVersionExperimentTreatment)
 
         public init(from decoder: Decoder) throws {
-            if let appPreviewSet = try? AppPreviewSet(from: decoder) {
-                self = .appPreviewSet(appPreviewSet)
-            } else if let appScreenshotSet = try? AppScreenshotSet(from: decoder) {
-                self = .appScreenshotSet(appScreenshotSet)
-            } else if let appStoreVersionExperimentTreatment = try? AppStoreVersionExperimentTreatment(from: decoder) {
-                self = .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appPreviewSets":
+                self = .appPreviewSet(try AppPreviewSet(from: decoder))
+            case "appScreenshotSets":
+                self = .appScreenshotSet(try AppScreenshotSet(from: decoder))
+            case "appStoreVersionExperimentTreatments":
+                self = .appStoreVersionExperimentTreatment(try AppStoreVersionExperimentTreatment(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationsResponse.swift
@@ -81,18 +81,20 @@ public struct AppStoreVersionExperimentTreatmentLocalizationsResponse: Codable, 
         case appStoreVersionExperimentTreatment(AppStoreVersionExperimentTreatment)
 
         public init(from decoder: Decoder) throws {
-            if let appPreviewSet = try? AppPreviewSet(from: decoder) {
-                self = .appPreviewSet(appPreviewSet)
-            } else if let appScreenshotSet = try? AppScreenshotSet(from: decoder) {
-                self = .appScreenshotSet(appScreenshotSet)
-            } else if let appStoreVersionExperimentTreatment = try? AppStoreVersionExperimentTreatment(from: decoder) {
-                self = .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appPreviewSets":
+                self = .appPreviewSet(try AppPreviewSet(from: decoder))
+            case "appScreenshotSets":
+                self = .appScreenshotSet(try AppScreenshotSet(from: decoder))
+            case "appStoreVersionExperimentTreatments":
+                self = .appStoreVersionExperimentTreatment(try AppStoreVersionExperimentTreatment(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentResponse.swift
@@ -68,16 +68,18 @@ public struct AppStoreVersionExperimentTreatmentResponse: Codable, Sendable {
         case appStoreVersionExperimentTreatmentLocalization(AppStoreVersionExperimentTreatmentLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appStoreVersionExperiment = try? AppStoreVersionExperiment(from: decoder) {
-                self = .appStoreVersionExperiment(appStoreVersionExperiment)
-            } else if let appStoreVersionExperimentTreatmentLocalization = try? AppStoreVersionExperimentTreatmentLocalization(from: decoder) {
-                self = .appStoreVersionExperimentTreatmentLocalization(appStoreVersionExperimentTreatmentLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperiment(try AppStoreVersionExperiment(from: decoder))
+            case "appStoreVersionExperimentTreatmentLocalizations":
+                self = .appStoreVersionExperimentTreatmentLocalization(try AppStoreVersionExperimentTreatmentLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentsResponse.swift
@@ -75,16 +75,18 @@ public struct AppStoreVersionExperimentTreatmentsResponse: Codable, Sendable, Pa
         case appStoreVersionExperimentTreatmentLocalization(AppStoreVersionExperimentTreatmentLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let appStoreVersionExperiment = try? AppStoreVersionExperiment(from: decoder) {
-                self = .appStoreVersionExperiment(appStoreVersionExperiment)
-            } else if let appStoreVersionExperimentTreatmentLocalization = try? AppStoreVersionExperimentTreatmentLocalization(from: decoder) {
-                self = .appStoreVersionExperimentTreatmentLocalization(appStoreVersionExperimentTreatmentLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperiment(try AppStoreVersionExperiment(from: decoder))
+            case "appStoreVersionExperimentTreatmentLocalizations":
+                self = .appStoreVersionExperimentTreatmentLocalization(try AppStoreVersionExperimentTreatmentLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentV2Response.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentV2Response.swift
@@ -81,18 +81,20 @@ public struct AppStoreVersionExperimentV2Response: Codable, Sendable {
         case appStoreVersionExperimentTreatment(AppStoreVersionExperimentTreatment)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperimentTreatment = try? AppStoreVersionExperimentTreatment(from: decoder) {
-                self = .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperimentTreatments":
+                self = .appStoreVersionExperimentTreatment(try AppStoreVersionExperimentTreatment(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentsResponse.swift
@@ -61,16 +61,18 @@ public struct AppStoreVersionExperimentsResponse: Codable, Sendable, PagedRespon
         case appStoreVersionExperimentTreatment(AppStoreVersionExperimentTreatment)
 
         public init(from decoder: Decoder) throws {
-            if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperimentTreatment = try? AppStoreVersionExperimentTreatment(from: decoder) {
-                self = .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperimentTreatments":
+                self = .appStoreVersionExperimentTreatment(try AppStoreVersionExperimentTreatment(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentsV2Response.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentsV2Response.swift
@@ -88,18 +88,20 @@ public struct AppStoreVersionExperimentsV2Response: Codable, Sendable, PagedResp
         case appStoreVersionExperimentTreatment(AppStoreVersionExperimentTreatment)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperimentTreatment = try? AppStoreVersionExperimentTreatment(from: decoder) {
-                self = .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperimentTreatments":
+                self = .appStoreVersionExperimentTreatment(try AppStoreVersionExperimentTreatment(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationResponse.swift
@@ -87,20 +87,22 @@ public struct AppStoreVersionLocalizationResponse: Codable, Sendable {
         case appStoreVersion(AppStoreVersion)
 
         public init(from decoder: Decoder) throws {
-            if let appKeyword = try? AppKeyword(from: decoder) {
-                self = .appKeyword(appKeyword)
-            } else if let appPreviewSet = try? AppPreviewSet(from: decoder) {
-                self = .appPreviewSet(appPreviewSet)
-            } else if let appScreenshotSet = try? AppScreenshotSet(from: decoder) {
-                self = .appScreenshotSet(appScreenshotSet)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appKeywords":
+                self = .appKeyword(try AppKeyword(from: decoder))
+            case "appPreviewSets":
+                self = .appPreviewSet(try AppPreviewSet(from: decoder))
+            case "appScreenshotSets":
+                self = .appScreenshotSet(try AppScreenshotSet(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationsResponse.swift
@@ -94,20 +94,22 @@ public struct AppStoreVersionLocalizationsResponse: Codable, Sendable, PagedResp
         case appStoreVersion(AppStoreVersion)
 
         public init(from decoder: Decoder) throws {
-            if let appKeyword = try? AppKeyword(from: decoder) {
-                self = .appKeyword(appKeyword)
-            } else if let appPreviewSet = try? AppPreviewSet(from: decoder) {
-                self = .appPreviewSet(appPreviewSet)
-            } else if let appScreenshotSet = try? AppScreenshotSet(from: decoder) {
-                self = .appScreenshotSet(appScreenshotSet)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appKeywords":
+                self = .appKeyword(try AppKeyword(from: decoder))
+            case "appPreviewSets":
+                self = .appPreviewSet(try AppPreviewSet(from: decoder))
+            case "appScreenshotSets":
+                self = .appScreenshotSet(try AppScreenshotSet(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionResponse.swift
@@ -150,34 +150,36 @@ public struct AppStoreVersionResponse: Codable, Sendable {
         case routingAppCoverage(RoutingAppCoverage)
 
         public init(from decoder: Decoder) throws {
-            if let alternativeDistributionPackage = try? AlternativeDistributionPackage(from: decoder) {
-                self = .alternativeDistributionPackage(alternativeDistributionPackage)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appClipDefaultExperience = try? AppClipDefaultExperience(from: decoder) {
-                self = .appClipDefaultExperience(appClipDefaultExperience)
-            } else if let appStoreReviewDetail = try? AppStoreReviewDetail(from: decoder) {
-                self = .appStoreReviewDetail(appStoreReviewDetail)
-            } else if let appStoreVersionExperiment = try? AppStoreVersionExperiment(from: decoder) {
-                self = .appStoreVersionExperiment(appStoreVersionExperiment)
-            } else if let appStoreVersionLocalization = try? AppStoreVersionLocalization(from: decoder) {
-                self = .appStoreVersionLocalization(appStoreVersionLocalization)
-            } else if let appStoreVersionPhasedRelease = try? AppStoreVersionPhasedRelease(from: decoder) {
-                self = .appStoreVersionPhasedRelease(appStoreVersionPhasedRelease)
-            } else if let appStoreVersionSubmission = try? AppStoreVersionSubmission(from: decoder) {
-                self = .appStoreVersionSubmission(appStoreVersionSubmission)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let gameCenterAppVersion = try? GameCenterAppVersion(from: decoder) {
-                self = .gameCenterAppVersion(gameCenterAppVersion)
-            } else if let routingAppCoverage = try? RoutingAppCoverage(from: decoder) {
-                self = .routingAppCoverage(routingAppCoverage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "alternativeDistributionPackages":
+                self = .alternativeDistributionPackage(try AlternativeDistributionPackage(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appClipDefaultExperiences":
+                self = .appClipDefaultExperience(try AppClipDefaultExperience(from: decoder))
+            case "appStoreReviewDetails":
+                self = .appStoreReviewDetail(try AppStoreReviewDetail(from: decoder))
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperiment(try AppStoreVersionExperiment(from: decoder))
+            case "appStoreVersionLocalizations":
+                self = .appStoreVersionLocalization(try AppStoreVersionLocalization(from: decoder))
+            case "appStoreVersionPhasedReleases":
+                self = .appStoreVersionPhasedRelease(try AppStoreVersionPhasedRelease(from: decoder))
+            case "appStoreVersionSubmissions":
+                self = .appStoreVersionSubmission(try AppStoreVersionSubmission(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "gameCenterAppVersions":
+                self = .gameCenterAppVersion(try GameCenterAppVersion(from: decoder))
+            case "routingAppCoverages":
+                self = .routingAppCoverage(try RoutingAppCoverage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionsResponse.swift
@@ -157,34 +157,36 @@ public struct AppStoreVersionsResponse: Codable, Sendable, PagedResponse {
         case routingAppCoverage(RoutingAppCoverage)
 
         public init(from decoder: Decoder) throws {
-            if let alternativeDistributionPackage = try? AlternativeDistributionPackage(from: decoder) {
-                self = .alternativeDistributionPackage(alternativeDistributionPackage)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appClipDefaultExperience = try? AppClipDefaultExperience(from: decoder) {
-                self = .appClipDefaultExperience(appClipDefaultExperience)
-            } else if let appStoreReviewDetail = try? AppStoreReviewDetail(from: decoder) {
-                self = .appStoreReviewDetail(appStoreReviewDetail)
-            } else if let appStoreVersionExperiment = try? AppStoreVersionExperiment(from: decoder) {
-                self = .appStoreVersionExperiment(appStoreVersionExperiment)
-            } else if let appStoreVersionLocalization = try? AppStoreVersionLocalization(from: decoder) {
-                self = .appStoreVersionLocalization(appStoreVersionLocalization)
-            } else if let appStoreVersionPhasedRelease = try? AppStoreVersionPhasedRelease(from: decoder) {
-                self = .appStoreVersionPhasedRelease(appStoreVersionPhasedRelease)
-            } else if let appStoreVersionSubmission = try? AppStoreVersionSubmission(from: decoder) {
-                self = .appStoreVersionSubmission(appStoreVersionSubmission)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let gameCenterAppVersion = try? GameCenterAppVersion(from: decoder) {
-                self = .gameCenterAppVersion(gameCenterAppVersion)
-            } else if let routingAppCoverage = try? RoutingAppCoverage(from: decoder) {
-                self = .routingAppCoverage(routingAppCoverage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "alternativeDistributionPackages":
+                self = .alternativeDistributionPackage(try AlternativeDistributionPackage(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appClipDefaultExperiences":
+                self = .appClipDefaultExperience(try AppClipDefaultExperience(from: decoder))
+            case "appStoreReviewDetails":
+                self = .appStoreReviewDetail(try AppStoreReviewDetail(from: decoder))
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperiment(try AppStoreVersionExperiment(from: decoder))
+            case "appStoreVersionLocalizations":
+                self = .appStoreVersionLocalization(try AppStoreVersionLocalization(from: decoder))
+            case "appStoreVersionPhasedReleases":
+                self = .appStoreVersionPhasedRelease(try AppStoreVersionPhasedRelease(from: decoder))
+            case "appStoreVersionSubmissions":
+                self = .appStoreVersionSubmission(try AppStoreVersionSubmission(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "gameCenterAppVersions":
+                self = .gameCenterAppVersion(try GameCenterAppVersion(from: decoder))
+            case "routingAppCoverages":
+                self = .routingAppCoverage(try RoutingAppCoverage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/AppsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppsResponse.swift
@@ -327,60 +327,62 @@ public struct AppsResponse: Codable, Sendable, PagedResponse {
         case subscriptionGroup(SubscriptionGroup)
 
         public init(from decoder: Decoder) throws {
-            if let androidToIosAppMappingDetail = try? AndroidToIosAppMappingDetail(from: decoder) {
-                self = .androidToIosAppMappingDetail(androidToIosAppMappingDetail)
-            } else if let appClip = try? AppClip(from: decoder) {
-                self = .appClip(appClip)
-            } else if let appCustomProductPage = try? AppCustomProductPage(from: decoder) {
-                self = .appCustomProductPage(appCustomProductPage)
-            } else if let appEncryptionDeclaration = try? AppEncryptionDeclaration(from: decoder) {
-                self = .appEncryptionDeclaration(appEncryptionDeclaration)
-            } else if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let appInfo = try? AppInfo(from: decoder) {
-                self = .appInfo(appInfo)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperimentV2 = try? AppStoreVersionExperimentV2(from: decoder) {
-                self = .appStoreVersionExperimentV2(appStoreVersionExperimentV2)
-            } else if let betaAppLocalization = try? BetaAppLocalization(from: decoder) {
-                self = .betaAppLocalization(betaAppLocalization)
-            } else if let betaAppReviewDetail = try? BetaAppReviewDetail(from: decoder) {
-                self = .betaAppReviewDetail(betaAppReviewDetail)
-            } else if let betaGroup = try? BetaGroup(from: decoder) {
-                self = .betaGroup(betaGroup)
-            } else if let betaLicenseAgreement = try? BetaLicenseAgreement(from: decoder) {
-                self = .betaLicenseAgreement(betaLicenseAgreement)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let buildIcon = try? BuildIcon(from: decoder) {
-                self = .buildIcon(buildIcon)
-            } else if let ciProduct = try? CiProduct(from: decoder) {
-                self = .ciProduct(ciProduct)
-            } else if let endUserLicenseAgreement = try? EndUserLicenseAgreement(from: decoder) {
-                self = .endUserLicenseAgreement(endUserLicenseAgreement)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterEnabledVersion = try? GameCenterEnabledVersion(from: decoder) {
-                self = .gameCenterEnabledVersion(gameCenterEnabledVersion)
-            } else if let inAppPurchase = try? InAppPurchase(from: decoder) {
-                self = .inAppPurchase(inAppPurchase)
-            } else if let prereleaseVersion = try? PrereleaseVersion(from: decoder) {
-                self = .prereleaseVersion(prereleaseVersion)
-            } else if let promotedPurchase = try? PromotedPurchase(from: decoder) {
-                self = .promotedPurchase(promotedPurchase)
-            } else if let reviewSubmission = try? ReviewSubmission(from: decoder) {
-                self = .reviewSubmission(reviewSubmission)
-            } else if let subscriptionGracePeriod = try? SubscriptionGracePeriod(from: decoder) {
-                self = .subscriptionGracePeriod(subscriptionGracePeriod)
-            } else if let subscriptionGroup = try? SubscriptionGroup(from: decoder) {
-                self = .subscriptionGroup(subscriptionGroup)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "androidToIosAppMappingDetails":
+                self = .androidToIosAppMappingDetail(try AndroidToIosAppMappingDetail(from: decoder))
+            case "appClips":
+                self = .appClip(try AppClip(from: decoder))
+            case "appCustomProductPages":
+                self = .appCustomProductPage(try AppCustomProductPage(from: decoder))
+            case "appEncryptionDeclarations":
+                self = .appEncryptionDeclaration(try AppEncryptionDeclaration(from: decoder))
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "appInfos":
+                self = .appInfo(try AppInfo(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperimentV2(try AppStoreVersionExperimentV2(from: decoder))
+            case "betaAppLocalizations":
+                self = .betaAppLocalization(try BetaAppLocalization(from: decoder))
+            case "betaAppReviewDetails":
+                self = .betaAppReviewDetail(try BetaAppReviewDetail(from: decoder))
+            case "betaGroups":
+                self = .betaGroup(try BetaGroup(from: decoder))
+            case "betaLicenseAgreements":
+                self = .betaLicenseAgreement(try BetaLicenseAgreement(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "buildIcons":
+                self = .buildIcon(try BuildIcon(from: decoder))
+            case "ciProducts":
+                self = .ciProduct(try CiProduct(from: decoder))
+            case "endUserLicenseAgreements":
+                self = .endUserLicenseAgreement(try EndUserLicenseAgreement(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterEnabledVersions":
+                self = .gameCenterEnabledVersion(try GameCenterEnabledVersion(from: decoder))
+            case "inAppPurchases":
+                self = .inAppPurchase(try InAppPurchase(from: decoder))
+            case "preReleaseVersions":
+                self = .prereleaseVersion(try PrereleaseVersion(from: decoder))
+            case "promotedPurchases":
+                self = .promotedPurchase(try PromotedPurchase(from: decoder))
+            case "reviewSubmissions":
+                self = .reviewSubmission(try ReviewSubmission(from: decoder))
+            case "subscriptionGracePeriods":
+                self = .subscriptionGracePeriod(try SubscriptionGracePeriod(from: decoder))
+            case "subscriptionGroups":
+                self = .subscriptionGroup(try SubscriptionGroup(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BackgroundAssetResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BackgroundAssetResponse.swift
@@ -70,16 +70,18 @@ public struct BackgroundAssetResponse: Codable, Sendable {
         case backgroundAssetVersion(BackgroundAssetVersion)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let backgroundAssetVersion = try? BackgroundAssetVersion(from: decoder) {
-                self = .backgroundAssetVersion(backgroundAssetVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "backgroundAssetVersions":
+                self = .backgroundAssetVersion(try BackgroundAssetVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BackgroundAssetVersionResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BackgroundAssetVersionResponse.swift
@@ -87,22 +87,24 @@ public struct BackgroundAssetVersionResponse: Codable, Sendable {
         case backgroundAssetVersionInternalBetaRelease(BackgroundAssetVersionInternalBetaRelease)
 
         public init(from decoder: Decoder) throws {
-            if let backgroundAsset = try? BackgroundAsset(from: decoder) {
-                self = .backgroundAsset(backgroundAsset)
-            } else if let backgroundAssetUploadFile = try? BackgroundAssetUploadFile(from: decoder) {
-                self = .backgroundAssetUploadFile(backgroundAssetUploadFile)
-            } else if let backgroundAssetVersionAppStoreRelease = try? BackgroundAssetVersionAppStoreRelease(from: decoder) {
-                self = .backgroundAssetVersionAppStoreRelease(backgroundAssetVersionAppStoreRelease)
-            } else if let backgroundAssetVersionExternalBetaRelease = try? BackgroundAssetVersionExternalBetaRelease(from: decoder) {
-                self = .backgroundAssetVersionExternalBetaRelease(backgroundAssetVersionExternalBetaRelease)
-            } else if let backgroundAssetVersionInternalBetaRelease = try? BackgroundAssetVersionInternalBetaRelease(from: decoder) {
-                self = .backgroundAssetVersionInternalBetaRelease(backgroundAssetVersionInternalBetaRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "backgroundAssets":
+                self = .backgroundAsset(try BackgroundAsset(from: decoder))
+            case "backgroundAssetUploadFiles":
+                self = .backgroundAssetUploadFile(try BackgroundAssetUploadFile(from: decoder))
+            case "backgroundAssetVersionAppStoreReleases":
+                self = .backgroundAssetVersionAppStoreRelease(try BackgroundAssetVersionAppStoreRelease(from: decoder))
+            case "backgroundAssetVersionExternalBetaReleases":
+                self = .backgroundAssetVersionExternalBetaRelease(try BackgroundAssetVersionExternalBetaRelease(from: decoder))
+            case "backgroundAssetVersionInternalBetaReleases":
+                self = .backgroundAssetVersionInternalBetaRelease(try BackgroundAssetVersionInternalBetaRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BackgroundAssetVersionsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BackgroundAssetVersionsResponse.swift
@@ -94,22 +94,24 @@ public struct BackgroundAssetVersionsResponse: Codable, Sendable, PagedResponse 
         case backgroundAssetVersionInternalBetaRelease(BackgroundAssetVersionInternalBetaRelease)
 
         public init(from decoder: Decoder) throws {
-            if let backgroundAsset = try? BackgroundAsset(from: decoder) {
-                self = .backgroundAsset(backgroundAsset)
-            } else if let backgroundAssetUploadFile = try? BackgroundAssetUploadFile(from: decoder) {
-                self = .backgroundAssetUploadFile(backgroundAssetUploadFile)
-            } else if let backgroundAssetVersionAppStoreRelease = try? BackgroundAssetVersionAppStoreRelease(from: decoder) {
-                self = .backgroundAssetVersionAppStoreRelease(backgroundAssetVersionAppStoreRelease)
-            } else if let backgroundAssetVersionExternalBetaRelease = try? BackgroundAssetVersionExternalBetaRelease(from: decoder) {
-                self = .backgroundAssetVersionExternalBetaRelease(backgroundAssetVersionExternalBetaRelease)
-            } else if let backgroundAssetVersionInternalBetaRelease = try? BackgroundAssetVersionInternalBetaRelease(from: decoder) {
-                self = .backgroundAssetVersionInternalBetaRelease(backgroundAssetVersionInternalBetaRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "backgroundAssets":
+                self = .backgroundAsset(try BackgroundAsset(from: decoder))
+            case "backgroundAssetUploadFiles":
+                self = .backgroundAssetUploadFile(try BackgroundAssetUploadFile(from: decoder))
+            case "backgroundAssetVersionAppStoreReleases":
+                self = .backgroundAssetVersionAppStoreRelease(try BackgroundAssetVersionAppStoreRelease(from: decoder))
+            case "backgroundAssetVersionExternalBetaReleases":
+                self = .backgroundAssetVersionExternalBetaRelease(try BackgroundAssetVersionExternalBetaRelease(from: decoder))
+            case "backgroundAssetVersionInternalBetaReleases":
+                self = .backgroundAssetVersionInternalBetaRelease(try BackgroundAssetVersionInternalBetaRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BackgroundAssetsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BackgroundAssetsResponse.swift
@@ -77,16 +77,18 @@ public struct BackgroundAssetsResponse: Codable, Sendable, PagedResponse {
         case backgroundAssetVersion(BackgroundAssetVersion)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let backgroundAssetVersion = try? BackgroundAssetVersion(from: decoder) {
-                self = .backgroundAssetVersion(backgroundAssetVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "backgroundAssetVersions":
+                self = .backgroundAssetVersion(try BackgroundAssetVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BuildResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BuildResponse.swift
@@ -163,36 +163,38 @@ public struct BuildResponse: Codable, Sendable {
         case prereleaseVersion(PrereleaseVersion)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appEncryptionDeclaration = try? AppEncryptionDeclaration(from: decoder) {
-                self = .appEncryptionDeclaration(appEncryptionDeclaration)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let betaAppReviewSubmission = try? BetaAppReviewSubmission(from: decoder) {
-                self = .betaAppReviewSubmission(betaAppReviewSubmission)
-            } else if let betaBuildLocalization = try? BetaBuildLocalization(from: decoder) {
-                self = .betaBuildLocalization(betaBuildLocalization)
-            } else if let betaGroup = try? BetaGroup(from: decoder) {
-                self = .betaGroup(betaGroup)
-            } else if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let buildBetaDetail = try? BuildBetaDetail(from: decoder) {
-                self = .buildBetaDetail(buildBetaDetail)
-            } else if let buildBundle = try? BuildBundle(from: decoder) {
-                self = .buildBundle(buildBundle)
-            } else if let buildIcon = try? BuildIcon(from: decoder) {
-                self = .buildIcon(buildIcon)
-            } else if let buildUpload = try? BuildUpload(from: decoder) {
-                self = .buildUpload(buildUpload)
-            } else if let prereleaseVersion = try? PrereleaseVersion(from: decoder) {
-                self = .prereleaseVersion(prereleaseVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appEncryptionDeclarations":
+                self = .appEncryptionDeclaration(try AppEncryptionDeclaration(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "betaAppReviewSubmissions":
+                self = .betaAppReviewSubmission(try BetaAppReviewSubmission(from: decoder))
+            case "betaBuildLocalizations":
+                self = .betaBuildLocalization(try BetaBuildLocalization(from: decoder))
+            case "betaGroups":
+                self = .betaGroup(try BetaGroup(from: decoder))
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "buildBetaDetails":
+                self = .buildBetaDetail(try BuildBetaDetail(from: decoder))
+            case "buildBundles":
+                self = .buildBundle(try BuildBundle(from: decoder))
+            case "buildIcons":
+                self = .buildIcon(try BuildIcon(from: decoder))
+            case "buildUploads":
+                self = .buildUpload(try BuildUpload(from: decoder))
+            case "preReleaseVersions":
+                self = .prereleaseVersion(try PrereleaseVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BuildUploadResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BuildUploadResponse.swift
@@ -70,16 +70,18 @@ public struct BuildUploadResponse: Codable, Sendable {
         case buildUploadFile(BuildUploadFile)
 
         public init(from decoder: Decoder) throws {
-            if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let buildUploadFile = try? BuildUploadFile(from: decoder) {
-                self = .buildUploadFile(buildUploadFile)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "buildUploadFiles":
+                self = .buildUploadFile(try BuildUploadFile(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BuildUploadsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BuildUploadsResponse.swift
@@ -77,16 +77,18 @@ public struct BuildUploadsResponse: Codable, Sendable, PagedResponse {
         case buildUploadFile(BuildUploadFile)
 
         public init(from decoder: Decoder) throws {
-            if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let buildUploadFile = try? BuildUploadFile(from: decoder) {
-                self = .buildUploadFile(buildUploadFile)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "buildUploadFiles":
+                self = .buildUploadFile(try BuildUploadFile(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/BuildsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/BuildsResponse.swift
@@ -171,36 +171,38 @@ public struct BuildsResponse: Codable, Sendable, PagedResponse {
         case prereleaseVersion(PrereleaseVersion)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appEncryptionDeclaration = try? AppEncryptionDeclaration(from: decoder) {
-                self = .appEncryptionDeclaration(appEncryptionDeclaration)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let betaAppReviewSubmission = try? BetaAppReviewSubmission(from: decoder) {
-                self = .betaAppReviewSubmission(betaAppReviewSubmission)
-            } else if let betaBuildLocalization = try? BetaBuildLocalization(from: decoder) {
-                self = .betaBuildLocalization(betaBuildLocalization)
-            } else if let betaGroup = try? BetaGroup(from: decoder) {
-                self = .betaGroup(betaGroup)
-            } else if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let buildBetaDetail = try? BuildBetaDetail(from: decoder) {
-                self = .buildBetaDetail(buildBetaDetail)
-            } else if let buildBundle = try? BuildBundle(from: decoder) {
-                self = .buildBundle(buildBundle)
-            } else if let buildIcon = try? BuildIcon(from: decoder) {
-                self = .buildIcon(buildIcon)
-            } else if let buildUpload = try? BuildUpload(from: decoder) {
-                self = .buildUpload(buildUpload)
-            } else if let prereleaseVersion = try? PrereleaseVersion(from: decoder) {
-                self = .prereleaseVersion(prereleaseVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appEncryptionDeclarations":
+                self = .appEncryptionDeclaration(try AppEncryptionDeclaration(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "betaAppReviewSubmissions":
+                self = .betaAppReviewSubmission(try BetaAppReviewSubmission(from: decoder))
+            case "betaBuildLocalizations":
+                self = .betaBuildLocalization(try BetaBuildLocalization(from: decoder))
+            case "betaGroups":
+                self = .betaGroup(try BetaGroup(from: decoder))
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "buildBetaDetails":
+                self = .buildBetaDetail(try BuildBetaDetail(from: decoder))
+            case "buildBundles":
+                self = .buildBundle(try BuildBundle(from: decoder))
+            case "buildIcons":
+                self = .buildIcon(try BuildIcon(from: decoder))
+            case "buildUploads":
+                self = .buildUpload(try BuildUpload(from: decoder))
+            case "preReleaseVersions":
+                self = .prereleaseVersion(try PrereleaseVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/CustomerReviewResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/CustomerReviewResponse.swift
@@ -59,16 +59,18 @@ public struct CustomerReviewResponse: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let customerReviewResponseV1 = try? CustomerReviewResponseV1(from: decoder) {
-                self = .customerReviewResponseV1(customerReviewResponseV1)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "customerReviewResponses":
+                self = .customerReviewResponseV1(try CustomerReviewResponseV1(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/CustomerReviewsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/CustomerReviewsResponse.swift
@@ -67,16 +67,18 @@ public struct CustomerReviewsResponse: Codable, Sendable, PagedResponse {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let customerReviewResponseV1 = try? CustomerReviewResponseV1(from: decoder) {
-                self = .customerReviewResponseV1(customerReviewResponseV1)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "customerReviewResponses":
+                self = .customerReviewResponseV1(try CustomerReviewResponseV1(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/EndUserLicenseAgreementResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/EndUserLicenseAgreementResponse.swift
@@ -61,16 +61,18 @@ public struct EndUserLicenseAgreementResponse: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/InAppPurchaseOfferCodeResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/InAppPurchaseOfferCodeResponse.swift
@@ -79,18 +79,20 @@ public struct InAppPurchaseOfferCodeResponse: Codable, Sendable {
         case inAppPurchaseOfferPrice(InAppPurchaseOfferPrice)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchaseOfferCodeCustomCode = try? InAppPurchaseOfferCodeCustomCode(from: decoder) {
-                self = .inAppPurchaseOfferCodeCustomCode(inAppPurchaseOfferCodeCustomCode)
-            } else if let inAppPurchaseOfferCodeOneTimeUseCode = try? InAppPurchaseOfferCodeOneTimeUseCode(from: decoder) {
-                self = .inAppPurchaseOfferCodeOneTimeUseCode(inAppPurchaseOfferCodeOneTimeUseCode)
-            } else if let inAppPurchaseOfferPrice = try? InAppPurchaseOfferPrice(from: decoder) {
-                self = .inAppPurchaseOfferPrice(inAppPurchaseOfferPrice)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchaseOfferCodeCustomCodes":
+                self = .inAppPurchaseOfferCodeCustomCode(try InAppPurchaseOfferCodeCustomCode(from: decoder))
+            case "inAppPurchaseOfferCodeOneTimeUseCodes":
+                self = .inAppPurchaseOfferCodeOneTimeUseCode(try InAppPurchaseOfferCodeOneTimeUseCode(from: decoder))
+            case "inAppPurchaseOfferPrices":
+                self = .inAppPurchaseOfferPrice(try InAppPurchaseOfferPrice(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/InAppPurchaseOfferCodesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/InAppPurchaseOfferCodesResponse.swift
@@ -86,18 +86,20 @@ public struct InAppPurchaseOfferCodesResponse: Codable, Sendable, PagedResponse 
         case inAppPurchaseOfferPrice(InAppPurchaseOfferPrice)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchaseOfferCodeCustomCode = try? InAppPurchaseOfferCodeCustomCode(from: decoder) {
-                self = .inAppPurchaseOfferCodeCustomCode(inAppPurchaseOfferCodeCustomCode)
-            } else if let inAppPurchaseOfferCodeOneTimeUseCode = try? InAppPurchaseOfferCodeOneTimeUseCode(from: decoder) {
-                self = .inAppPurchaseOfferCodeOneTimeUseCode(inAppPurchaseOfferCodeOneTimeUseCode)
-            } else if let inAppPurchaseOfferPrice = try? InAppPurchaseOfferPrice(from: decoder) {
-                self = .inAppPurchaseOfferPrice(inAppPurchaseOfferPrice)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchaseOfferCodeCustomCodes":
+                self = .inAppPurchaseOfferCodeCustomCode(try InAppPurchaseOfferCodeCustomCode(from: decoder))
+            case "inAppPurchaseOfferCodeOneTimeUseCodes":
+                self = .inAppPurchaseOfferCodeOneTimeUseCode(try InAppPurchaseOfferCodeOneTimeUseCode(from: decoder))
+            case "inAppPurchaseOfferPrices":
+                self = .inAppPurchaseOfferPrice(try InAppPurchaseOfferPrice(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/InAppPurchaseOfferPricesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/InAppPurchaseOfferPricesResponse.swift
@@ -63,16 +63,18 @@ public struct InAppPurchaseOfferPricesResponse: Codable, Sendable, PagedResponse
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchasePricePoint = try? InAppPurchasePricePoint(from: decoder) {
-                self = .inAppPurchasePricePoint(inAppPurchasePricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchasePricePoints":
+                self = .inAppPurchasePricePoint(try InAppPurchasePricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/InAppPurchasePriceScheduleResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/InAppPurchasePriceScheduleResponse.swift
@@ -66,16 +66,18 @@ public struct InAppPurchasePriceScheduleResponse: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchasePrice = try? InAppPurchasePrice(from: decoder) {
-                self = .inAppPurchasePrice(inAppPurchasePrice)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchasePrices":
+                self = .inAppPurchasePrice(try InAppPurchasePrice(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/InAppPurchasePricesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/InAppPurchasePricesResponse.swift
@@ -56,16 +56,18 @@ public struct InAppPurchasePricesResponse: Codable, Sendable, PagedResponse {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchasePricePoint = try? InAppPurchasePricePoint(from: decoder) {
-                self = .inAppPurchasePricePoint(inAppPurchasePricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchasePricePoints":
+                self = .inAppPurchasePricePoint(try InAppPurchasePricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/InAppPurchaseV2Response.swift
+++ b/Sources/Bagbutik-AppStore/Models/InAppPurchaseV2Response.swift
@@ -125,30 +125,32 @@ public struct InAppPurchaseV2Response: Codable, Sendable {
         case promotedPurchase(PromotedPurchase)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchaseAppStoreReviewScreenshot = try? InAppPurchaseAppStoreReviewScreenshot(from: decoder) {
-                self = .inAppPurchaseAppStoreReviewScreenshot(inAppPurchaseAppStoreReviewScreenshot)
-            } else if let inAppPurchaseAvailability = try? InAppPurchaseAvailability(from: decoder) {
-                self = .inAppPurchaseAvailability(inAppPurchaseAvailability)
-            } else if let inAppPurchaseContent = try? InAppPurchaseContent(from: decoder) {
-                self = .inAppPurchaseContent(inAppPurchaseContent)
-            } else if let inAppPurchaseImage = try? InAppPurchaseImage(from: decoder) {
-                self = .inAppPurchaseImage(inAppPurchaseImage)
-            } else if let inAppPurchaseLocalization = try? InAppPurchaseLocalization(from: decoder) {
-                self = .inAppPurchaseLocalization(inAppPurchaseLocalization)
-            } else if let inAppPurchaseOfferCode = try? InAppPurchaseOfferCode(from: decoder) {
-                self = .inAppPurchaseOfferCode(inAppPurchaseOfferCode)
-            } else if let inAppPurchasePricePoint = try? InAppPurchasePricePoint(from: decoder) {
-                self = .inAppPurchasePricePoint(inAppPurchasePricePoint)
-            } else if let inAppPurchasePriceSchedule = try? InAppPurchasePriceSchedule(from: decoder) {
-                self = .inAppPurchasePriceSchedule(inAppPurchasePriceSchedule)
-            } else if let promotedPurchase = try? PromotedPurchase(from: decoder) {
-                self = .promotedPurchase(promotedPurchase)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchaseAppStoreReviewScreenshots":
+                self = .inAppPurchaseAppStoreReviewScreenshot(try InAppPurchaseAppStoreReviewScreenshot(from: decoder))
+            case "inAppPurchaseAvailabilities":
+                self = .inAppPurchaseAvailability(try InAppPurchaseAvailability(from: decoder))
+            case "inAppPurchaseContents":
+                self = .inAppPurchaseContent(try InAppPurchaseContent(from: decoder))
+            case "inAppPurchaseImages":
+                self = .inAppPurchaseImage(try InAppPurchaseImage(from: decoder))
+            case "inAppPurchaseLocalizations":
+                self = .inAppPurchaseLocalization(try InAppPurchaseLocalization(from: decoder))
+            case "inAppPurchaseOfferCodes":
+                self = .inAppPurchaseOfferCode(try InAppPurchaseOfferCode(from: decoder))
+            case "inAppPurchasePricePoints":
+                self = .inAppPurchasePricePoint(try InAppPurchasePricePoint(from: decoder))
+            case "inAppPurchasePriceSchedules":
+                self = .inAppPurchasePriceSchedule(try InAppPurchasePriceSchedule(from: decoder))
+            case "promotedPurchases":
+                self = .promotedPurchase(try PromotedPurchase(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/InAppPurchasesV2Response.swift
+++ b/Sources/Bagbutik-AppStore/Models/InAppPurchasesV2Response.swift
@@ -132,30 +132,32 @@ public struct InAppPurchasesV2Response: Codable, Sendable, PagedResponse {
         case promotedPurchase(PromotedPurchase)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchaseAppStoreReviewScreenshot = try? InAppPurchaseAppStoreReviewScreenshot(from: decoder) {
-                self = .inAppPurchaseAppStoreReviewScreenshot(inAppPurchaseAppStoreReviewScreenshot)
-            } else if let inAppPurchaseAvailability = try? InAppPurchaseAvailability(from: decoder) {
-                self = .inAppPurchaseAvailability(inAppPurchaseAvailability)
-            } else if let inAppPurchaseContent = try? InAppPurchaseContent(from: decoder) {
-                self = .inAppPurchaseContent(inAppPurchaseContent)
-            } else if let inAppPurchaseImage = try? InAppPurchaseImage(from: decoder) {
-                self = .inAppPurchaseImage(inAppPurchaseImage)
-            } else if let inAppPurchaseLocalization = try? InAppPurchaseLocalization(from: decoder) {
-                self = .inAppPurchaseLocalization(inAppPurchaseLocalization)
-            } else if let inAppPurchaseOfferCode = try? InAppPurchaseOfferCode(from: decoder) {
-                self = .inAppPurchaseOfferCode(inAppPurchaseOfferCode)
-            } else if let inAppPurchasePricePoint = try? InAppPurchasePricePoint(from: decoder) {
-                self = .inAppPurchasePricePoint(inAppPurchasePricePoint)
-            } else if let inAppPurchasePriceSchedule = try? InAppPurchasePriceSchedule(from: decoder) {
-                self = .inAppPurchasePriceSchedule(inAppPurchasePriceSchedule)
-            } else if let promotedPurchase = try? PromotedPurchase(from: decoder) {
-                self = .promotedPurchase(promotedPurchase)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchaseAppStoreReviewScreenshots":
+                self = .inAppPurchaseAppStoreReviewScreenshot(try InAppPurchaseAppStoreReviewScreenshot(from: decoder))
+            case "inAppPurchaseAvailabilities":
+                self = .inAppPurchaseAvailability(try InAppPurchaseAvailability(from: decoder))
+            case "inAppPurchaseContents":
+                self = .inAppPurchaseContent(try InAppPurchaseContent(from: decoder))
+            case "inAppPurchaseImages":
+                self = .inAppPurchaseImage(try InAppPurchaseImage(from: decoder))
+            case "inAppPurchaseLocalizations":
+                self = .inAppPurchaseLocalization(try InAppPurchaseLocalization(from: decoder))
+            case "inAppPurchaseOfferCodes":
+                self = .inAppPurchaseOfferCode(try InAppPurchaseOfferCode(from: decoder))
+            case "inAppPurchasePricePoints":
+                self = .inAppPurchasePricePoint(try InAppPurchasePricePoint(from: decoder))
+            case "inAppPurchasePriceSchedules":
+                self = .inAppPurchasePriceSchedule(try InAppPurchasePriceSchedule(from: decoder))
+            case "promotedPurchases":
+                self = .promotedPurchase(try PromotedPurchase(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/NominationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/NominationResponse.swift
@@ -101,20 +101,22 @@ public struct NominationResponse: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let actor = try? Actor(from: decoder) {
-                self = .actor(actor)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "actors":
+                self = .actor(try Actor(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/NominationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/NominationsResponse.swift
@@ -108,20 +108,22 @@ public struct NominationsResponse: Codable, Sendable, PagedResponse {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let actor = try? Actor(from: decoder) {
-                self = .actor(actor)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "actors":
+                self = .actor(try Actor(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/PromotedPurchaseResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/PromotedPurchaseResponse.swift
@@ -49,16 +49,18 @@ public struct PromotedPurchaseResponse: Codable, Sendable {
         case subscription(Subscription)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchaseV2 = try? InAppPurchaseV2(from: decoder) {
-                self = .inAppPurchaseV2(inAppPurchaseV2)
-            } else if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchases":
+                self = .inAppPurchaseV2(try InAppPurchaseV2(from: decoder))
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/PromotedPurchasesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/PromotedPurchasesResponse.swift
@@ -56,16 +56,18 @@ public struct PromotedPurchasesResponse: Codable, Sendable, PagedResponse {
         case subscription(Subscription)
 
         public init(from decoder: Decoder) throws {
-            if let inAppPurchaseV2 = try? InAppPurchaseV2(from: decoder) {
-                self = .inAppPurchaseV2(inAppPurchaseV2)
-            } else if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "inAppPurchases":
+                self = .inAppPurchaseV2(try InAppPurchaseV2(from: decoder))
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/ReviewSubmissionItemResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/ReviewSubmissionItemResponse.swift
@@ -120,32 +120,34 @@ public struct ReviewSubmissionItemResponse: Codable, Sendable {
         case gameCenterLeaderboardVersionV2(GameCenterLeaderboardVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageVersion = try? AppCustomProductPageVersion(from: decoder) {
-                self = .appCustomProductPageVersion(appCustomProductPageVersion)
-            } else if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperiment = try? AppStoreVersionExperiment(from: decoder) {
-                self = .appStoreVersionExperiment(appStoreVersionExperiment)
-            } else if let backgroundAssetVersion = try? BackgroundAssetVersion(from: decoder) {
-                self = .backgroundAssetVersion(backgroundAssetVersion)
-            } else if let gameCenterAchievementVersionV2 = try? GameCenterAchievementVersionV2(from: decoder) {
-                self = .gameCenterAchievementVersionV2(gameCenterAchievementVersionV2)
-            } else if let gameCenterActivityVersion = try? GameCenterActivityVersion(from: decoder) {
-                self = .gameCenterActivityVersion(gameCenterActivityVersion)
-            } else if let gameCenterChallengeVersion = try? GameCenterChallengeVersion(from: decoder) {
-                self = .gameCenterChallengeVersion(gameCenterChallengeVersion)
-            } else if let gameCenterLeaderboardSetVersionV2 = try? GameCenterLeaderboardSetVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardSetVersionV2(gameCenterLeaderboardSetVersionV2)
-            } else if let gameCenterLeaderboardVersionV2 = try? GameCenterLeaderboardVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardVersionV2(gameCenterLeaderboardVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageVersions":
+                self = .appCustomProductPageVersion(try AppCustomProductPageVersion(from: decoder))
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperiment(try AppStoreVersionExperiment(from: decoder))
+            case "backgroundAssetVersions":
+                self = .backgroundAssetVersion(try BackgroundAssetVersion(from: decoder))
+            case "gameCenterAchievementVersions":
+                self = .gameCenterAchievementVersionV2(try GameCenterAchievementVersionV2(from: decoder))
+            case "gameCenterActivityVersions":
+                self = .gameCenterActivityVersion(try GameCenterActivityVersion(from: decoder))
+            case "gameCenterChallengeVersions":
+                self = .gameCenterChallengeVersion(try GameCenterChallengeVersion(from: decoder))
+            case "gameCenterLeaderboardSetVersions":
+                self = .gameCenterLeaderboardSetVersionV2(try GameCenterLeaderboardSetVersionV2(from: decoder))
+            case "gameCenterLeaderboardVersions":
+                self = .gameCenterLeaderboardVersionV2(try GameCenterLeaderboardVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/ReviewSubmissionItemsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/ReviewSubmissionItemsResponse.swift
@@ -127,32 +127,34 @@ public struct ReviewSubmissionItemsResponse: Codable, Sendable, PagedResponse {
         case gameCenterLeaderboardVersionV2(GameCenterLeaderboardVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let appCustomProductPageVersion = try? AppCustomProductPageVersion(from: decoder) {
-                self = .appCustomProductPageVersion(appCustomProductPageVersion)
-            } else if let appEvent = try? AppEvent(from: decoder) {
-                self = .appEvent(appEvent)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let appStoreVersionExperiment = try? AppStoreVersionExperiment(from: decoder) {
-                self = .appStoreVersionExperiment(appStoreVersionExperiment)
-            } else if let backgroundAssetVersion = try? BackgroundAssetVersion(from: decoder) {
-                self = .backgroundAssetVersion(backgroundAssetVersion)
-            } else if let gameCenterAchievementVersionV2 = try? GameCenterAchievementVersionV2(from: decoder) {
-                self = .gameCenterAchievementVersionV2(gameCenterAchievementVersionV2)
-            } else if let gameCenterActivityVersion = try? GameCenterActivityVersion(from: decoder) {
-                self = .gameCenterActivityVersion(gameCenterActivityVersion)
-            } else if let gameCenterChallengeVersion = try? GameCenterChallengeVersion(from: decoder) {
-                self = .gameCenterChallengeVersion(gameCenterChallengeVersion)
-            } else if let gameCenterLeaderboardSetVersionV2 = try? GameCenterLeaderboardSetVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardSetVersionV2(gameCenterLeaderboardSetVersionV2)
-            } else if let gameCenterLeaderboardVersionV2 = try? GameCenterLeaderboardVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardVersionV2(gameCenterLeaderboardVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appCustomProductPageVersions":
+                self = .appCustomProductPageVersion(try AppCustomProductPageVersion(from: decoder))
+            case "appEvents":
+                self = .appEvent(try AppEvent(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "appStoreVersionExperiments":
+                self = .appStoreVersionExperiment(try AppStoreVersionExperiment(from: decoder))
+            case "backgroundAssetVersions":
+                self = .backgroundAssetVersion(try BackgroundAssetVersion(from: decoder))
+            case "gameCenterAchievementVersions":
+                self = .gameCenterAchievementVersionV2(try GameCenterAchievementVersionV2(from: decoder))
+            case "gameCenterActivityVersions":
+                self = .gameCenterActivityVersion(try GameCenterActivityVersion(from: decoder))
+            case "gameCenterChallengeVersions":
+                self = .gameCenterChallengeVersion(try GameCenterChallengeVersion(from: decoder))
+            case "gameCenterLeaderboardSetVersions":
+                self = .gameCenterLeaderboardSetVersionV2(try GameCenterLeaderboardSetVersionV2(from: decoder))
+            case "gameCenterLeaderboardVersions":
+                self = .gameCenterLeaderboardVersionV2(try GameCenterLeaderboardVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/ReviewSubmissionResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/ReviewSubmissionResponse.swift
@@ -84,20 +84,22 @@ public struct ReviewSubmissionResponse: Codable, Sendable {
         case reviewSubmissionItem(ReviewSubmissionItem)
 
         public init(from decoder: Decoder) throws {
-            if let actor = try? Actor(from: decoder) {
-                self = .actor(actor)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let reviewSubmissionItem = try? ReviewSubmissionItem(from: decoder) {
-                self = .reviewSubmissionItem(reviewSubmissionItem)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "actors":
+                self = .actor(try Actor(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "reviewSubmissionItems":
+                self = .reviewSubmissionItem(try ReviewSubmissionItem(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/ReviewSubmissionsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/ReviewSubmissionsResponse.swift
@@ -91,20 +91,22 @@ public struct ReviewSubmissionsResponse: Codable, Sendable, PagedResponse {
         case reviewSubmissionItem(ReviewSubmissionItem)
 
         public init(from decoder: Decoder) throws {
-            if let actor = try? Actor(from: decoder) {
-                self = .actor(actor)
-            } else if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let reviewSubmissionItem = try? ReviewSubmissionItem(from: decoder) {
-                self = .reviewSubmissionItem(reviewSubmissionItem)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "actors":
+                self = .actor(try Actor(from: decoder))
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "reviewSubmissionItems":
+                self = .reviewSubmissionItem(try ReviewSubmissionItem(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionGroupResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionGroupResponse.swift
@@ -59,16 +59,18 @@ public struct SubscriptionGroupResponse: Codable, Sendable {
         case subscriptionGroupLocalization(SubscriptionGroupLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionGroupLocalization = try? SubscriptionGroupLocalization(from: decoder) {
-                self = .subscriptionGroupLocalization(subscriptionGroupLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionGroupLocalizations":
+                self = .subscriptionGroupLocalization(try SubscriptionGroupLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionGroupsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionGroupsResponse.swift
@@ -66,16 +66,18 @@ public struct SubscriptionGroupsResponse: Codable, Sendable, PagedResponse {
         case subscriptionGroupLocalization(SubscriptionGroupLocalization)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionGroupLocalization = try? SubscriptionGroupLocalization(from: decoder) {
-                self = .subscriptionGroupLocalization(subscriptionGroupLocalization)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionGroupLocalizations":
+                self = .subscriptionGroupLocalization(try SubscriptionGroupLocalization(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionIntroductoryOfferResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionIntroductoryOfferResponse.swift
@@ -57,18 +57,20 @@ public struct SubscriptionIntroductoryOfferResponse: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionPricePoint = try? SubscriptionPricePoint(from: decoder) {
-                self = .subscriptionPricePoint(subscriptionPricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionPricePoints":
+                self = .subscriptionPricePoint(try SubscriptionPricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionIntroductoryOffersResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionIntroductoryOffersResponse.swift
@@ -64,18 +64,20 @@ public struct SubscriptionIntroductoryOffersResponse: Codable, Sendable, PagedRe
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionPricePoint = try? SubscriptionPricePoint(from: decoder) {
-                self = .subscriptionPricePoint(subscriptionPricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionPricePoints":
+                self = .subscriptionPricePoint(try SubscriptionPricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionOfferCodePricesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionOfferCodePricesResponse.swift
@@ -56,16 +56,18 @@ public struct SubscriptionOfferCodePricesResponse: Codable, Sendable, PagedRespo
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let subscriptionPricePoint = try? SubscriptionPricePoint(from: decoder) {
-                self = .subscriptionPricePoint(subscriptionPricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptionPricePoints":
+                self = .subscriptionPricePoint(try SubscriptionPricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionOfferCodeResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionOfferCodeResponse.swift
@@ -80,20 +80,22 @@ public struct SubscriptionOfferCodeResponse: Codable, Sendable {
         case subscriptionOfferCodePrice(SubscriptionOfferCodePrice)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionOfferCodeCustomCode = try? SubscriptionOfferCodeCustomCode(from: decoder) {
-                self = .subscriptionOfferCodeCustomCode(subscriptionOfferCodeCustomCode)
-            } else if let subscriptionOfferCodeOneTimeUseCode = try? SubscriptionOfferCodeOneTimeUseCode(from: decoder) {
-                self = .subscriptionOfferCodeOneTimeUseCode(subscriptionOfferCodeOneTimeUseCode)
-            } else if let subscriptionOfferCodePrice = try? SubscriptionOfferCodePrice(from: decoder) {
-                self = .subscriptionOfferCodePrice(subscriptionOfferCodePrice)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionOfferCodeCustomCodes":
+                self = .subscriptionOfferCodeCustomCode(try SubscriptionOfferCodeCustomCode(from: decoder))
+            case "subscriptionOfferCodeOneTimeUseCodes":
+                self = .subscriptionOfferCodeOneTimeUseCode(try SubscriptionOfferCodeOneTimeUseCode(from: decoder))
+            case "subscriptionOfferCodePrices":
+                self = .subscriptionOfferCodePrice(try SubscriptionOfferCodePrice(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionOfferCodesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionOfferCodesResponse.swift
@@ -87,20 +87,22 @@ public struct SubscriptionOfferCodesResponse: Codable, Sendable, PagedResponse {
         case subscriptionOfferCodePrice(SubscriptionOfferCodePrice)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionOfferCodeCustomCode = try? SubscriptionOfferCodeCustomCode(from: decoder) {
-                self = .subscriptionOfferCodeCustomCode(subscriptionOfferCodeCustomCode)
-            } else if let subscriptionOfferCodeOneTimeUseCode = try? SubscriptionOfferCodeOneTimeUseCode(from: decoder) {
-                self = .subscriptionOfferCodeOneTimeUseCode(subscriptionOfferCodeOneTimeUseCode)
-            } else if let subscriptionOfferCodePrice = try? SubscriptionOfferCodePrice(from: decoder) {
-                self = .subscriptionOfferCodePrice(subscriptionOfferCodePrice)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionOfferCodeCustomCodes":
+                self = .subscriptionOfferCodeCustomCode(try SubscriptionOfferCodeCustomCode(from: decoder))
+            case "subscriptionOfferCodeOneTimeUseCodes":
+                self = .subscriptionOfferCodeOneTimeUseCode(try SubscriptionOfferCodeOneTimeUseCode(from: decoder))
+            case "subscriptionOfferCodePrices":
+                self = .subscriptionOfferCodePrice(try SubscriptionOfferCodePrice(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionPriceResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionPriceResponse.swift
@@ -49,16 +49,18 @@ public struct SubscriptionPriceResponse: Codable, Sendable {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let subscriptionPricePoint = try? SubscriptionPricePoint(from: decoder) {
-                self = .subscriptionPricePoint(subscriptionPricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptionPricePoints":
+                self = .subscriptionPricePoint(try SubscriptionPricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionPricesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionPricesResponse.swift
@@ -56,16 +56,18 @@ public struct SubscriptionPricesResponse: Codable, Sendable, PagedResponse {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let subscriptionPricePoint = try? SubscriptionPricePoint(from: decoder) {
-                self = .subscriptionPricePoint(subscriptionPricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptionPricePoints":
+                self = .subscriptionPricePoint(try SubscriptionPricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionPromotionalOfferPricesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionPromotionalOfferPricesResponse.swift
@@ -56,16 +56,18 @@ public struct SubscriptionPromotionalOfferPricesResponse: Codable, Sendable, Pag
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let subscriptionPricePoint = try? SubscriptionPricePoint(from: decoder) {
-                self = .subscriptionPricePoint(subscriptionPricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptionPricePoints":
+                self = .subscriptionPricePoint(try SubscriptionPricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionPromotionalOfferResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionPromotionalOfferResponse.swift
@@ -54,16 +54,18 @@ public struct SubscriptionPromotionalOfferResponse: Codable, Sendable {
         case subscriptionPromotionalOfferPrice(SubscriptionPromotionalOfferPrice)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionPromotionalOfferPrice = try? SubscriptionPromotionalOfferPrice(from: decoder) {
-                self = .subscriptionPromotionalOfferPrice(subscriptionPromotionalOfferPrice)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionPromotionalOfferPrices":
+                self = .subscriptionPromotionalOfferPrice(try SubscriptionPromotionalOfferPrice(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionPromotionalOffersResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionPromotionalOffersResponse.swift
@@ -61,16 +61,18 @@ public struct SubscriptionPromotionalOffersResponse: Codable, Sendable, PagedRes
         case subscriptionPromotionalOfferPrice(SubscriptionPromotionalOfferPrice)
 
         public init(from decoder: Decoder) throws {
-            if let subscription = try? Subscription(from: decoder) {
-                self = .subscription(subscription)
-            } else if let subscriptionPromotionalOfferPrice = try? SubscriptionPromotionalOfferPrice(from: decoder) {
-                self = .subscriptionPromotionalOfferPrice(subscriptionPromotionalOfferPrice)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptions":
+                self = .subscription(try Subscription(from: decoder))
+            case "subscriptionPromotionalOfferPrices":
+                self = .subscriptionPromotionalOfferPrice(try SubscriptionPromotionalOfferPrice(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionResponse.swift
@@ -156,34 +156,36 @@ public struct SubscriptionResponse: Codable, Sendable {
         case winBackOffer(WinBackOffer)
 
         public init(from decoder: Decoder) throws {
-            if let promotedPurchase = try? PromotedPurchase(from: decoder) {
-                self = .promotedPurchase(promotedPurchase)
-            } else if let subscriptionAppStoreReviewScreenshot = try? SubscriptionAppStoreReviewScreenshot(from: decoder) {
-                self = .subscriptionAppStoreReviewScreenshot(subscriptionAppStoreReviewScreenshot)
-            } else if let subscriptionAvailability = try? SubscriptionAvailability(from: decoder) {
-                self = .subscriptionAvailability(subscriptionAvailability)
-            } else if let subscriptionGroup = try? SubscriptionGroup(from: decoder) {
-                self = .subscriptionGroup(subscriptionGroup)
-            } else if let subscriptionImage = try? SubscriptionImage(from: decoder) {
-                self = .subscriptionImage(subscriptionImage)
-            } else if let subscriptionIntroductoryOffer = try? SubscriptionIntroductoryOffer(from: decoder) {
-                self = .subscriptionIntroductoryOffer(subscriptionIntroductoryOffer)
-            } else if let subscriptionLocalization = try? SubscriptionLocalization(from: decoder) {
-                self = .subscriptionLocalization(subscriptionLocalization)
-            } else if let subscriptionOfferCode = try? SubscriptionOfferCode(from: decoder) {
-                self = .subscriptionOfferCode(subscriptionOfferCode)
-            } else if let subscriptionPrice = try? SubscriptionPrice(from: decoder) {
-                self = .subscriptionPrice(subscriptionPrice)
-            } else if let subscriptionPromotionalOffer = try? SubscriptionPromotionalOffer(from: decoder) {
-                self = .subscriptionPromotionalOffer(subscriptionPromotionalOffer)
-            } else if let winBackOffer = try? WinBackOffer(from: decoder) {
-                self = .winBackOffer(winBackOffer)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "promotedPurchases":
+                self = .promotedPurchase(try PromotedPurchase(from: decoder))
+            case "subscriptionAppStoreReviewScreenshots":
+                self = .subscriptionAppStoreReviewScreenshot(try SubscriptionAppStoreReviewScreenshot(from: decoder))
+            case "subscriptionAvailabilities":
+                self = .subscriptionAvailability(try SubscriptionAvailability(from: decoder))
+            case "subscriptionGroups":
+                self = .subscriptionGroup(try SubscriptionGroup(from: decoder))
+            case "subscriptionImages":
+                self = .subscriptionImage(try SubscriptionImage(from: decoder))
+            case "subscriptionIntroductoryOffers":
+                self = .subscriptionIntroductoryOffer(try SubscriptionIntroductoryOffer(from: decoder))
+            case "subscriptionLocalizations":
+                self = .subscriptionLocalization(try SubscriptionLocalization(from: decoder))
+            case "subscriptionOfferCodes":
+                self = .subscriptionOfferCode(try SubscriptionOfferCode(from: decoder))
+            case "subscriptionPrices":
+                self = .subscriptionPrice(try SubscriptionPrice(from: decoder))
+            case "subscriptionPromotionalOffers":
+                self = .subscriptionPromotionalOffer(try SubscriptionPromotionalOffer(from: decoder))
+            case "winBackOffers":
+                self = .winBackOffer(try WinBackOffer(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionsResponse.swift
@@ -163,34 +163,36 @@ public struct SubscriptionsResponse: Codable, Sendable, PagedResponse {
         case winBackOffer(WinBackOffer)
 
         public init(from decoder: Decoder) throws {
-            if let promotedPurchase = try? PromotedPurchase(from: decoder) {
-                self = .promotedPurchase(promotedPurchase)
-            } else if let subscriptionAppStoreReviewScreenshot = try? SubscriptionAppStoreReviewScreenshot(from: decoder) {
-                self = .subscriptionAppStoreReviewScreenshot(subscriptionAppStoreReviewScreenshot)
-            } else if let subscriptionAvailability = try? SubscriptionAvailability(from: decoder) {
-                self = .subscriptionAvailability(subscriptionAvailability)
-            } else if let subscriptionGroup = try? SubscriptionGroup(from: decoder) {
-                self = .subscriptionGroup(subscriptionGroup)
-            } else if let subscriptionImage = try? SubscriptionImage(from: decoder) {
-                self = .subscriptionImage(subscriptionImage)
-            } else if let subscriptionIntroductoryOffer = try? SubscriptionIntroductoryOffer(from: decoder) {
-                self = .subscriptionIntroductoryOffer(subscriptionIntroductoryOffer)
-            } else if let subscriptionLocalization = try? SubscriptionLocalization(from: decoder) {
-                self = .subscriptionLocalization(subscriptionLocalization)
-            } else if let subscriptionOfferCode = try? SubscriptionOfferCode(from: decoder) {
-                self = .subscriptionOfferCode(subscriptionOfferCode)
-            } else if let subscriptionPrice = try? SubscriptionPrice(from: decoder) {
-                self = .subscriptionPrice(subscriptionPrice)
-            } else if let subscriptionPromotionalOffer = try? SubscriptionPromotionalOffer(from: decoder) {
-                self = .subscriptionPromotionalOffer(subscriptionPromotionalOffer)
-            } else if let winBackOffer = try? WinBackOffer(from: decoder) {
-                self = .winBackOffer(winBackOffer)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "promotedPurchases":
+                self = .promotedPurchase(try PromotedPurchase(from: decoder))
+            case "subscriptionAppStoreReviewScreenshots":
+                self = .subscriptionAppStoreReviewScreenshot(try SubscriptionAppStoreReviewScreenshot(from: decoder))
+            case "subscriptionAvailabilities":
+                self = .subscriptionAvailability(try SubscriptionAvailability(from: decoder))
+            case "subscriptionGroups":
+                self = .subscriptionGroup(try SubscriptionGroup(from: decoder))
+            case "subscriptionImages":
+                self = .subscriptionImage(try SubscriptionImage(from: decoder))
+            case "subscriptionIntroductoryOffers":
+                self = .subscriptionIntroductoryOffer(try SubscriptionIntroductoryOffer(from: decoder))
+            case "subscriptionLocalizations":
+                self = .subscriptionLocalization(try SubscriptionLocalization(from: decoder))
+            case "subscriptionOfferCodes":
+                self = .subscriptionOfferCode(try SubscriptionOfferCode(from: decoder))
+            case "subscriptionPrices":
+                self = .subscriptionPrice(try SubscriptionPrice(from: decoder))
+            case "subscriptionPromotionalOffers":
+                self = .subscriptionPromotionalOffer(try SubscriptionPromotionalOffer(from: decoder))
+            case "winBackOffers":
+                self = .winBackOffer(try WinBackOffer(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-AppStore/Models/WinBackOfferPricesResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/WinBackOfferPricesResponse.swift
@@ -63,16 +63,18 @@ public struct WinBackOfferPricesResponse: Codable, Sendable, PagedResponse {
         case territory(Territory)
 
         public init(from decoder: Decoder) throws {
-            if let subscriptionPricePoint = try? SubscriptionPricePoint(from: decoder) {
-                self = .subscriptionPricePoint(subscriptionPricePoint)
-            } else if let territory = try? Territory(from: decoder) {
-                self = .territory(territory)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "subscriptionPricePoints":
+                self = .subscriptionPricePoint(try SubscriptionPricePoint(from: decoder))
+            case "territories":
+                self = .territory(try Territory(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationResponse.swift
@@ -49,16 +49,18 @@ public struct GameCenterAchievementLocalizationResponse: Codable, Sendable {
         case gameCenterAchievementImage(GameCenterAchievementImage)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterAchievementImage = try? GameCenterAchievementImage(from: decoder) {
-                self = .gameCenterAchievementImage(gameCenterAchievementImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterAchievementImages":
+                self = .gameCenterAchievementImage(try GameCenterAchievementImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationV2Response.swift
@@ -56,16 +56,18 @@ public struct GameCenterAchievementLocalizationV2Response: Codable, Sendable {
         case gameCenterAchievementVersionV2(GameCenterAchievementVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievementImageV2 = try? GameCenterAchievementImageV2(from: decoder) {
-                self = .gameCenterAchievementImageV2(gameCenterAchievementImageV2)
-            } else if let gameCenterAchievementVersionV2 = try? GameCenterAchievementVersionV2(from: decoder) {
-                self = .gameCenterAchievementVersionV2(gameCenterAchievementVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievementImages":
+                self = .gameCenterAchievementImageV2(try GameCenterAchievementImageV2(from: decoder))
+            case "gameCenterAchievementVersions":
+                self = .gameCenterAchievementVersionV2(try GameCenterAchievementVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationsResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterAchievementLocalizationsResponse: Codable, Sendable, Pag
         case gameCenterAchievementImage(GameCenterAchievementImage)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterAchievementImage = try? GameCenterAchievementImage(from: decoder) {
-                self = .gameCenterAchievementImage(gameCenterAchievementImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterAchievementImages":
+                self = .gameCenterAchievementImage(try GameCenterAchievementImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementLocalizationsV2Response.swift
@@ -63,16 +63,18 @@ public struct GameCenterAchievementLocalizationsV2Response: Codable, Sendable, P
         case gameCenterAchievementVersionV2(GameCenterAchievementVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievementImageV2 = try? GameCenterAchievementImageV2(from: decoder) {
-                self = .gameCenterAchievementImageV2(gameCenterAchievementImageV2)
-            } else if let gameCenterAchievementVersionV2 = try? GameCenterAchievementVersionV2(from: decoder) {
-                self = .gameCenterAchievementVersionV2(gameCenterAchievementVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievementImages":
+                self = .gameCenterAchievementImageV2(try GameCenterAchievementImageV2(from: decoder))
+            case "gameCenterAchievementVersions":
+                self = .gameCenterAchievementVersionV2(try GameCenterAchievementVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementReleaseResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementReleaseResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterAchievementReleaseResponse: Codable, Sendable {
         case gameCenterDetail(GameCenterDetail)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementReleasesResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementReleasesResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterAchievementReleasesResponse: Codable, Sendable, PagedRes
         case gameCenterDetail(GameCenterDetail)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementResponse.swift
@@ -91,24 +91,26 @@ public struct GameCenterAchievementResponse: Codable, Sendable {
         case gameCenterGroup(GameCenterGroup)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterAchievementLocalization = try? GameCenterAchievementLocalization(from: decoder) {
-                self = .gameCenterAchievementLocalization(gameCenterAchievementLocalization)
-            } else if let gameCenterAchievementRelease = try? GameCenterAchievementRelease(from: decoder) {
-                self = .gameCenterAchievementRelease(gameCenterAchievementRelease)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterAchievementLocalizations":
+                self = .gameCenterAchievementLocalization(try GameCenterAchievementLocalization(from: decoder))
+            case "gameCenterAchievementReleases":
+                self = .gameCenterAchievementRelease(try GameCenterAchievementRelease(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementV2Response.swift
@@ -77,20 +77,22 @@ public struct GameCenterAchievementV2Response: Codable, Sendable {
         case gameCenterGroup(GameCenterGroup)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievementVersionV2 = try? GameCenterAchievementVersionV2(from: decoder) {
-                self = .gameCenterAchievementVersionV2(gameCenterAchievementVersionV2)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievementVersions":
+                self = .gameCenterAchievementVersionV2(try GameCenterAchievementVersionV2(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementVersionV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementVersionV2Response.swift
@@ -61,16 +61,18 @@ public struct GameCenterAchievementVersionV2Response: Codable, Sendable {
         case gameCenterAchievementV2(GameCenterAchievementV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievementLocalizationV2 = try? GameCenterAchievementLocalizationV2(from: decoder) {
-                self = .gameCenterAchievementLocalizationV2(gameCenterAchievementLocalizationV2)
-            } else if let gameCenterAchievementV2 = try? GameCenterAchievementV2(from: decoder) {
-                self = .gameCenterAchievementV2(gameCenterAchievementV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievementLocalizations":
+                self = .gameCenterAchievementLocalizationV2(try GameCenterAchievementLocalizationV2(from: decoder))
+            case "gameCenterAchievements":
+                self = .gameCenterAchievementV2(try GameCenterAchievementV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementVersionsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementVersionsV2Response.swift
@@ -68,16 +68,18 @@ public struct GameCenterAchievementVersionsV2Response: Codable, Sendable, PagedR
         case gameCenterAchievementV2(GameCenterAchievementV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievementLocalizationV2 = try? GameCenterAchievementLocalizationV2(from: decoder) {
-                self = .gameCenterAchievementLocalizationV2(gameCenterAchievementLocalizationV2)
-            } else if let gameCenterAchievementV2 = try? GameCenterAchievementV2(from: decoder) {
-                self = .gameCenterAchievementV2(gameCenterAchievementV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievementLocalizations":
+                self = .gameCenterAchievementLocalizationV2(try GameCenterAchievementLocalizationV2(from: decoder))
+            case "gameCenterAchievements":
+                self = .gameCenterAchievementV2(try GameCenterAchievementV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementsResponse.swift
@@ -98,24 +98,26 @@ public struct GameCenterAchievementsResponse: Codable, Sendable, PagedResponse {
         case gameCenterGroup(GameCenterGroup)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterAchievementLocalization = try? GameCenterAchievementLocalization(from: decoder) {
-                self = .gameCenterAchievementLocalization(gameCenterAchievementLocalization)
-            } else if let gameCenterAchievementRelease = try? GameCenterAchievementRelease(from: decoder) {
-                self = .gameCenterAchievementRelease(gameCenterAchievementRelease)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterAchievementLocalizations":
+                self = .gameCenterAchievementLocalization(try GameCenterAchievementLocalization(from: decoder))
+            case "gameCenterAchievementReleases":
+                self = .gameCenterAchievementRelease(try GameCenterAchievementRelease(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementsV2Response.swift
@@ -84,20 +84,22 @@ public struct GameCenterAchievementsV2Response: Codable, Sendable, PagedResponse
         case gameCenterGroup(GameCenterGroup)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievementVersionV2 = try? GameCenterAchievementVersionV2(from: decoder) {
-                self = .gameCenterAchievementVersionV2(gameCenterAchievementVersionV2)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievementVersions":
+                self = .gameCenterAchievementVersionV2(try GameCenterAchievementVersionV2(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivitiesResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivitiesResponse.swift
@@ -102,22 +102,24 @@ public struct GameCenterActivitiesResponse: Codable, Sendable, PagedResponse {
         case gameCenterLeaderboard(GameCenterLeaderboard)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterActivityVersion = try? GameCenterActivityVersion(from: decoder) {
-                self = .gameCenterActivityVersion(gameCenterActivityVersion)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterActivityVersions":
+                self = .gameCenterActivityVersion(try GameCenterActivityVersion(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivityLocalizationResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivityLocalizationResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterActivityLocalizationResponse: Codable, Sendable {
         case gameCenterActivityVersion(GameCenterActivityVersion)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivityImage = try? GameCenterActivityImage(from: decoder) {
-                self = .gameCenterActivityImage(gameCenterActivityImage)
-            } else if let gameCenterActivityVersion = try? GameCenterActivityVersion(from: decoder) {
-                self = .gameCenterActivityVersion(gameCenterActivityVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivityImages":
+                self = .gameCenterActivityImage(try GameCenterActivityImage(from: decoder))
+            case "gameCenterActivityVersions":
+                self = .gameCenterActivityVersion(try GameCenterActivityVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivityLocalizationsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivityLocalizationsResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterActivityLocalizationsResponse: Codable, Sendable, PagedR
         case gameCenterActivityVersion(GameCenterActivityVersion)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivityImage = try? GameCenterActivityImage(from: decoder) {
-                self = .gameCenterActivityImage(gameCenterActivityImage)
-            } else if let gameCenterActivityVersion = try? GameCenterActivityVersion(from: decoder) {
-                self = .gameCenterActivityVersion(gameCenterActivityVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivityImages":
+                self = .gameCenterActivityImage(try GameCenterActivityImage(from: decoder))
+            case "gameCenterActivityVersions":
+                self = .gameCenterActivityVersion(try GameCenterActivityVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivityResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivityResponse.swift
@@ -95,22 +95,24 @@ public struct GameCenterActivityResponse: Codable, Sendable {
         case gameCenterLeaderboard(GameCenterLeaderboard)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterActivityVersion = try? GameCenterActivityVersion(from: decoder) {
-                self = .gameCenterActivityVersion(gameCenterActivityVersion)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterActivityVersions":
+                self = .gameCenterActivityVersion(try GameCenterActivityVersion(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivityVersionResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivityVersionResponse.swift
@@ -82,20 +82,22 @@ public struct GameCenterActivityVersionResponse: Codable, Sendable {
         case gameCenterActivityVersionRelease(GameCenterActivityVersionRelease)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterActivityImage = try? GameCenterActivityImage(from: decoder) {
-                self = .gameCenterActivityImage(gameCenterActivityImage)
-            } else if let gameCenterActivityLocalization = try? GameCenterActivityLocalization(from: decoder) {
-                self = .gameCenterActivityLocalization(gameCenterActivityLocalization)
-            } else if let gameCenterActivityVersionRelease = try? GameCenterActivityVersionRelease(from: decoder) {
-                self = .gameCenterActivityVersionRelease(gameCenterActivityVersionRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterActivityImages":
+                self = .gameCenterActivityImage(try GameCenterActivityImage(from: decoder))
+            case "gameCenterActivityLocalizations":
+                self = .gameCenterActivityLocalization(try GameCenterActivityLocalization(from: decoder))
+            case "gameCenterActivityVersionReleases":
+                self = .gameCenterActivityVersionRelease(try GameCenterActivityVersionRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivityVersionsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivityVersionsResponse.swift
@@ -89,20 +89,22 @@ public struct GameCenterActivityVersionsResponse: Codable, Sendable, PagedRespon
         case gameCenterActivityVersionRelease(GameCenterActivityVersionRelease)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterActivityImage = try? GameCenterActivityImage(from: decoder) {
-                self = .gameCenterActivityImage(gameCenterActivityImage)
-            } else if let gameCenterActivityLocalization = try? GameCenterActivityLocalization(from: decoder) {
-                self = .gameCenterActivityLocalization(gameCenterActivityLocalization)
-            } else if let gameCenterActivityVersionRelease = try? GameCenterActivityVersionRelease(from: decoder) {
-                self = .gameCenterActivityVersionRelease(gameCenterActivityVersionRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterActivityImages":
+                self = .gameCenterActivityImage(try GameCenterActivityImage(from: decoder))
+            case "gameCenterActivityLocalizations":
+                self = .gameCenterActivityLocalization(try GameCenterActivityLocalization(from: decoder))
+            case "gameCenterActivityVersionReleases":
+                self = .gameCenterActivityVersionRelease(try GameCenterActivityVersionRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAppVersionResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAppVersionResponse.swift
@@ -61,16 +61,18 @@ public struct GameCenterAppVersionResponse: Codable, Sendable {
         case gameCenterAppVersion(GameCenterAppVersion)
 
         public init(from decoder: Decoder) throws {
-            if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let gameCenterAppVersion = try? GameCenterAppVersion(from: decoder) {
-                self = .gameCenterAppVersion(gameCenterAppVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "gameCenterAppVersions":
+                self = .gameCenterAppVersion(try GameCenterAppVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAppVersionsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAppVersionsResponse.swift
@@ -68,16 +68,18 @@ public struct GameCenterAppVersionsResponse: Codable, Sendable, PagedResponse {
         case gameCenterAppVersion(GameCenterAppVersion)
 
         public init(from decoder: Decoder) throws {
-            if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let gameCenterAppVersion = try? GameCenterAppVersion(from: decoder) {
-                self = .gameCenterAppVersion(gameCenterAppVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "gameCenterAppVersions":
+                self = .gameCenterAppVersion(try GameCenterAppVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeLocalizationResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeLocalizationResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterChallengeLocalizationResponse: Codable, Sendable {
         case gameCenterChallengeVersion(GameCenterChallengeVersion)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterChallengeImage = try? GameCenterChallengeImage(from: decoder) {
-                self = .gameCenterChallengeImage(gameCenterChallengeImage)
-            } else if let gameCenterChallengeVersion = try? GameCenterChallengeVersion(from: decoder) {
-                self = .gameCenterChallengeVersion(gameCenterChallengeVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterChallengeImages":
+                self = .gameCenterChallengeImage(try GameCenterChallengeImage(from: decoder))
+            case "gameCenterChallengeVersions":
+                self = .gameCenterChallengeVersion(try GameCenterChallengeVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeLocalizationsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeLocalizationsResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterChallengeLocalizationsResponse: Codable, Sendable, Paged
         case gameCenterChallengeVersion(GameCenterChallengeVersion)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterChallengeImage = try? GameCenterChallengeImage(from: decoder) {
-                self = .gameCenterChallengeImage(gameCenterChallengeImage)
-            } else if let gameCenterChallengeVersion = try? GameCenterChallengeVersion(from: decoder) {
-                self = .gameCenterChallengeVersion(gameCenterChallengeVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterChallengeImages":
+                self = .gameCenterChallengeImage(try GameCenterChallengeImage(from: decoder))
+            case "gameCenterChallengeVersions":
+                self = .gameCenterChallengeVersion(try GameCenterChallengeVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeResponse.swift
@@ -77,20 +77,22 @@ public struct GameCenterChallengeResponse: Codable, Sendable {
         case gameCenterLeaderboard(GameCenterLeaderboard)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterChallengeVersion = try? GameCenterChallengeVersion(from: decoder) {
-                self = .gameCenterChallengeVersion(gameCenterChallengeVersion)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterChallengeVersions":
+                self = .gameCenterChallengeVersion(try GameCenterChallengeVersion(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeVersionResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeVersionResponse.swift
@@ -82,20 +82,22 @@ public struct GameCenterChallengeVersionResponse: Codable, Sendable {
         case gameCenterChallengeVersionRelease(GameCenterChallengeVersionRelease)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterChallengeImage = try? GameCenterChallengeImage(from: decoder) {
-                self = .gameCenterChallengeImage(gameCenterChallengeImage)
-            } else if let gameCenterChallengeLocalization = try? GameCenterChallengeLocalization(from: decoder) {
-                self = .gameCenterChallengeLocalization(gameCenterChallengeLocalization)
-            } else if let gameCenterChallengeVersionRelease = try? GameCenterChallengeVersionRelease(from: decoder) {
-                self = .gameCenterChallengeVersionRelease(gameCenterChallengeVersionRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterChallengeImages":
+                self = .gameCenterChallengeImage(try GameCenterChallengeImage(from: decoder))
+            case "gameCenterChallengeLocalizations":
+                self = .gameCenterChallengeLocalization(try GameCenterChallengeLocalization(from: decoder))
+            case "gameCenterChallengeVersionReleases":
+                self = .gameCenterChallengeVersionRelease(try GameCenterChallengeVersionRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeVersionsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeVersionsResponse.swift
@@ -89,20 +89,22 @@ public struct GameCenterChallengeVersionsResponse: Codable, Sendable, PagedRespo
         case gameCenterChallengeVersionRelease(GameCenterChallengeVersionRelease)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterChallengeImage = try? GameCenterChallengeImage(from: decoder) {
-                self = .gameCenterChallengeImage(gameCenterChallengeImage)
-            } else if let gameCenterChallengeLocalization = try? GameCenterChallengeLocalization(from: decoder) {
-                self = .gameCenterChallengeLocalization(gameCenterChallengeLocalization)
-            } else if let gameCenterChallengeVersionRelease = try? GameCenterChallengeVersionRelease(from: decoder) {
-                self = .gameCenterChallengeVersionRelease(gameCenterChallengeVersionRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterChallengeImages":
+                self = .gameCenterChallengeImage(try GameCenterChallengeImage(from: decoder))
+            case "gameCenterChallengeLocalizations":
+                self = .gameCenterChallengeLocalization(try GameCenterChallengeLocalization(from: decoder))
+            case "gameCenterChallengeVersionReleases":
+                self = .gameCenterChallengeVersionRelease(try GameCenterChallengeVersionRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengesResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengesResponse.swift
@@ -84,20 +84,22 @@ public struct GameCenterChallengesResponse: Codable, Sendable, PagedResponse {
         case gameCenterLeaderboard(GameCenterLeaderboard)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterChallengeVersion = try? GameCenterChallengeVersion(from: decoder) {
-                self = .gameCenterChallengeVersion(gameCenterChallengeVersion)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterChallengeVersions":
+                self = .gameCenterChallengeVersion(try GameCenterChallengeVersion(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterDetailResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterDetailResponse.swift
@@ -166,40 +166,42 @@ public struct GameCenterDetailResponse: Codable, Sendable {
         case gameCenterLeaderboardSetRelease(GameCenterLeaderboardSetRelease)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterAchievementRelease = try? GameCenterAchievementRelease(from: decoder) {
-                self = .gameCenterAchievementRelease(gameCenterAchievementRelease)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterActivityVersionRelease = try? GameCenterActivityVersionRelease(from: decoder) {
-                self = .gameCenterActivityVersionRelease(gameCenterActivityVersionRelease)
-            } else if let gameCenterAppVersion = try? GameCenterAppVersion(from: decoder) {
-                self = .gameCenterAppVersion(gameCenterAppVersion)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterChallengeVersionRelease = try? GameCenterChallengeVersionRelease(from: decoder) {
-                self = .gameCenterChallengeVersionRelease(gameCenterChallengeVersionRelease)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardRelease = try? GameCenterLeaderboardRelease(from: decoder) {
-                self = .gameCenterLeaderboardRelease(gameCenterLeaderboardRelease)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else if let gameCenterLeaderboardSetRelease = try? GameCenterLeaderboardSetRelease(from: decoder) {
-                self = .gameCenterLeaderboardSetRelease(gameCenterLeaderboardSetRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterAchievementReleases":
+                self = .gameCenterAchievementRelease(try GameCenterAchievementRelease(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterActivityVersionReleases":
+                self = .gameCenterActivityVersionRelease(try GameCenterActivityVersionRelease(from: decoder))
+            case "gameCenterAppVersions":
+                self = .gameCenterAppVersion(try GameCenterAppVersion(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterChallengeVersionReleases":
+                self = .gameCenterChallengeVersionRelease(try GameCenterChallengeVersionRelease(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardReleases":
+                self = .gameCenterLeaderboardRelease(try GameCenterLeaderboardRelease(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            case "gameCenterLeaderboardSetReleases":
+                self = .gameCenterLeaderboardSetRelease(try GameCenterLeaderboardSetRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterDetailsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterDetailsResponse.swift
@@ -173,40 +173,42 @@ public struct GameCenterDetailsResponse: Codable, Sendable, PagedResponse {
         case gameCenterLeaderboardSetRelease(GameCenterLeaderboardSetRelease)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let appStoreVersion = try? AppStoreVersion(from: decoder) {
-                self = .appStoreVersion(appStoreVersion)
-            } else if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterAchievementRelease = try? GameCenterAchievementRelease(from: decoder) {
-                self = .gameCenterAchievementRelease(gameCenterAchievementRelease)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterActivityVersionRelease = try? GameCenterActivityVersionRelease(from: decoder) {
-                self = .gameCenterActivityVersionRelease(gameCenterActivityVersionRelease)
-            } else if let gameCenterAppVersion = try? GameCenterAppVersion(from: decoder) {
-                self = .gameCenterAppVersion(gameCenterAppVersion)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterChallengeVersionRelease = try? GameCenterChallengeVersionRelease(from: decoder) {
-                self = .gameCenterChallengeVersionRelease(gameCenterChallengeVersionRelease)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardRelease = try? GameCenterLeaderboardRelease(from: decoder) {
-                self = .gameCenterLeaderboardRelease(gameCenterLeaderboardRelease)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else if let gameCenterLeaderboardSetRelease = try? GameCenterLeaderboardSetRelease(from: decoder) {
-                self = .gameCenterLeaderboardSetRelease(gameCenterLeaderboardSetRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "appStoreVersions":
+                self = .appStoreVersion(try AppStoreVersion(from: decoder))
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterAchievementReleases":
+                self = .gameCenterAchievementRelease(try GameCenterAchievementRelease(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterActivityVersionReleases":
+                self = .gameCenterActivityVersionRelease(try GameCenterActivityVersionRelease(from: decoder))
+            case "gameCenterAppVersions":
+                self = .gameCenterAppVersion(try GameCenterAppVersion(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterChallengeVersionReleases":
+                self = .gameCenterChallengeVersionRelease(try GameCenterChallengeVersionRelease(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardReleases":
+                self = .gameCenterLeaderboardRelease(try GameCenterLeaderboardRelease(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            case "gameCenterLeaderboardSetReleases":
+                self = .gameCenterLeaderboardSetRelease(try GameCenterLeaderboardSetRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterEnabledVersionsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterEnabledVersionsResponse.swift
@@ -68,16 +68,18 @@ public struct GameCenterEnabledVersionsResponse: Codable, Sendable, PagedRespons
         case gameCenterEnabledVersion(GameCenterEnabledVersion)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let gameCenterEnabledVersion = try? GameCenterEnabledVersion(from: decoder) {
-                self = .gameCenterEnabledVersion(gameCenterEnabledVersion)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "gameCenterEnabledVersions":
+                self = .gameCenterEnabledVersion(try GameCenterEnabledVersion(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterGroupResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterGroupResponse.swift
@@ -118,24 +118,26 @@ public struct GameCenterGroupResponse: Codable, Sendable {
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterGroupsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterGroupsResponse.swift
@@ -125,24 +125,26 @@ public struct GameCenterGroupsResponse: Codable, Sendable, PagedResponse {
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterAchievement = try? GameCenterAchievement(from: decoder) {
-                self = .gameCenterAchievement(gameCenterAchievement)
-            } else if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterAchievements":
+                self = .gameCenterAchievement(try GameCenterAchievement(from: decoder))
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterLeaderboardLocalizationResponse: Codable, Sendable {
         case gameCenterLeaderboardImage(GameCenterLeaderboardImage)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardImage = try? GameCenterLeaderboardImage(from: decoder) {
-                self = .gameCenterLeaderboardImage(gameCenterLeaderboardImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardImages":
+                self = .gameCenterLeaderboardImage(try GameCenterLeaderboardImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationV2Response.swift
@@ -56,16 +56,18 @@ public struct GameCenterLeaderboardLocalizationV2Response: Codable, Sendable {
         case gameCenterLeaderboardVersionV2(GameCenterLeaderboardVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardImageV2 = try? GameCenterLeaderboardImageV2(from: decoder) {
-                self = .gameCenterLeaderboardImageV2(gameCenterLeaderboardImageV2)
-            } else if let gameCenterLeaderboardVersionV2 = try? GameCenterLeaderboardVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardVersionV2(gameCenterLeaderboardVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardImages":
+                self = .gameCenterLeaderboardImageV2(try GameCenterLeaderboardImageV2(from: decoder))
+            case "gameCenterLeaderboardVersions":
+                self = .gameCenterLeaderboardVersionV2(try GameCenterLeaderboardVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationsResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterLeaderboardLocalizationsResponse: Codable, Sendable, Pag
         case gameCenterLeaderboardImage(GameCenterLeaderboardImage)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardImage = try? GameCenterLeaderboardImage(from: decoder) {
-                self = .gameCenterLeaderboardImage(gameCenterLeaderboardImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardImages":
+                self = .gameCenterLeaderboardImage(try GameCenterLeaderboardImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardLocalizationsV2Response.swift
@@ -63,16 +63,18 @@ public struct GameCenterLeaderboardLocalizationsV2Response: Codable, Sendable, P
         case gameCenterLeaderboardVersionV2(GameCenterLeaderboardVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardImageV2 = try? GameCenterLeaderboardImageV2(from: decoder) {
-                self = .gameCenterLeaderboardImageV2(gameCenterLeaderboardImageV2)
-            } else if let gameCenterLeaderboardVersionV2 = try? GameCenterLeaderboardVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardVersionV2(gameCenterLeaderboardVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardImages":
+                self = .gameCenterLeaderboardImageV2(try GameCenterLeaderboardImageV2(from: decoder))
+            case "gameCenterLeaderboardVersions":
+                self = .gameCenterLeaderboardVersionV2(try GameCenterLeaderboardVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardReleaseResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardReleaseResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterLeaderboardReleaseResponse: Codable, Sendable {
         case gameCenterLeaderboard(GameCenterLeaderboard)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardReleasesResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardReleasesResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterLeaderboardReleasesResponse: Codable, Sendable, PagedRes
         case gameCenterLeaderboard(GameCenterLeaderboard)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardResponse.swift
@@ -112,28 +112,30 @@ public struct GameCenterLeaderboardResponse: Codable, Sendable {
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardLocalization = try? GameCenterLeaderboardLocalization(from: decoder) {
-                self = .gameCenterLeaderboardLocalization(gameCenterLeaderboardLocalization)
-            } else if let gameCenterLeaderboardRelease = try? GameCenterLeaderboardRelease(from: decoder) {
-                self = .gameCenterLeaderboardRelease(gameCenterLeaderboardRelease)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardLocalizations":
+                self = .gameCenterLeaderboardLocalization(try GameCenterLeaderboardLocalization(from: decoder))
+            case "gameCenterLeaderboardReleases":
+                self = .gameCenterLeaderboardRelease(try GameCenterLeaderboardRelease(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterLeaderboardSetLocalizationResponse: Codable, Sendable {
         case gameCenterLeaderboardSetImage(GameCenterLeaderboardSetImage)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else if let gameCenterLeaderboardSetImage = try? GameCenterLeaderboardSetImage(from: decoder) {
-                self = .gameCenterLeaderboardSetImage(gameCenterLeaderboardSetImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            case "gameCenterLeaderboardSetImages":
+                self = .gameCenterLeaderboardSetImage(try GameCenterLeaderboardSetImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationV2Response.swift
@@ -56,16 +56,18 @@ public struct GameCenterLeaderboardSetLocalizationV2Response: Codable, Sendable 
         case gameCenterLeaderboardSetVersionV2(GameCenterLeaderboardSetVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardSetImageV2 = try? GameCenterLeaderboardSetImageV2(from: decoder) {
-                self = .gameCenterLeaderboardSetImageV2(gameCenterLeaderboardSetImageV2)
-            } else if let gameCenterLeaderboardSetVersionV2 = try? GameCenterLeaderboardSetVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardSetVersionV2(gameCenterLeaderboardSetVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardSetImages":
+                self = .gameCenterLeaderboardSetImageV2(try GameCenterLeaderboardSetImageV2(from: decoder))
+            case "gameCenterLeaderboardSetVersions":
+                self = .gameCenterLeaderboardSetVersionV2(try GameCenterLeaderboardSetVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationsResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterLeaderboardSetLocalizationsResponse: Codable, Sendable, 
         case gameCenterLeaderboardSetImage(GameCenterLeaderboardSetImage)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else if let gameCenterLeaderboardSetImage = try? GameCenterLeaderboardSetImage(from: decoder) {
-                self = .gameCenterLeaderboardSetImage(gameCenterLeaderboardSetImage)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            case "gameCenterLeaderboardSetImages":
+                self = .gameCenterLeaderboardSetImage(try GameCenterLeaderboardSetImage(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetLocalizationsV2Response.swift
@@ -63,16 +63,18 @@ public struct GameCenterLeaderboardSetLocalizationsV2Response: Codable, Sendable
         case gameCenterLeaderboardSetVersionV2(GameCenterLeaderboardSetVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardSetImageV2 = try? GameCenterLeaderboardSetImageV2(from: decoder) {
-                self = .gameCenterLeaderboardSetImageV2(gameCenterLeaderboardSetImageV2)
-            } else if let gameCenterLeaderboardSetVersionV2 = try? GameCenterLeaderboardSetVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardSetVersionV2(gameCenterLeaderboardSetVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardSetImages":
+                self = .gameCenterLeaderboardSetImageV2(try GameCenterLeaderboardSetImageV2(from: decoder))
+            case "gameCenterLeaderboardSetVersions":
+                self = .gameCenterLeaderboardSetVersionV2(try GameCenterLeaderboardSetVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetMemberLocalizationResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetMemberLocalizationResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterLeaderboardSetMemberLocalizationResponse: Codable, Senda
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetMemberLocalizationsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetMemberLocalizationsResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterLeaderboardSetMemberLocalizationsResponse: Codable, Send
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetReleaseResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetReleaseResponse.swift
@@ -56,16 +56,18 @@ public struct GameCenterLeaderboardSetReleaseResponse: Codable, Sendable {
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetReleasesResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetReleasesResponse.swift
@@ -63,16 +63,18 @@ public struct GameCenterLeaderboardSetReleasesResponse: Codable, Sendable, Paged
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetResponse.swift
@@ -96,24 +96,26 @@ public struct GameCenterLeaderboardSetResponse: Codable, Sendable {
         case gameCenterLeaderboardSetRelease(GameCenterLeaderboardSetRelease)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else if let gameCenterLeaderboardSetLocalization = try? GameCenterLeaderboardSetLocalization(from: decoder) {
-                self = .gameCenterLeaderboardSetLocalization(gameCenterLeaderboardSetLocalization)
-            } else if let gameCenterLeaderboardSetRelease = try? GameCenterLeaderboardSetRelease(from: decoder) {
-                self = .gameCenterLeaderboardSetRelease(gameCenterLeaderboardSetRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            case "gameCenterLeaderboardSetLocalizations":
+                self = .gameCenterLeaderboardSetLocalization(try GameCenterLeaderboardSetLocalization(from: decoder))
+            case "gameCenterLeaderboardSetReleases":
+                self = .gameCenterLeaderboardSetRelease(try GameCenterLeaderboardSetRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetV2Response.swift
@@ -82,20 +82,22 @@ public struct GameCenterLeaderboardSetV2Response: Codable, Sendable {
         case gameCenterLeaderboardV2(GameCenterLeaderboardV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboardSetVersionV2 = try? GameCenterLeaderboardSetVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardSetVersionV2(gameCenterLeaderboardSetVersionV2)
-            } else if let gameCenterLeaderboardV2 = try? GameCenterLeaderboardV2(from: decoder) {
-                self = .gameCenterLeaderboardV2(gameCenterLeaderboardV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboardSetVersions":
+                self = .gameCenterLeaderboardSetVersionV2(try GameCenterLeaderboardSetVersionV2(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboardV2(try GameCenterLeaderboardV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetVersionV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetVersionV2Response.swift
@@ -61,16 +61,18 @@ public struct GameCenterLeaderboardSetVersionV2Response: Codable, Sendable {
         case gameCenterLeaderboardSetV2(GameCenterLeaderboardSetV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardSetLocalizationV2 = try? GameCenterLeaderboardSetLocalizationV2(from: decoder) {
-                self = .gameCenterLeaderboardSetLocalizationV2(gameCenterLeaderboardSetLocalizationV2)
-            } else if let gameCenterLeaderboardSetV2 = try? GameCenterLeaderboardSetV2(from: decoder) {
-                self = .gameCenterLeaderboardSetV2(gameCenterLeaderboardSetV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardSetLocalizations":
+                self = .gameCenterLeaderboardSetLocalizationV2(try GameCenterLeaderboardSetLocalizationV2(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSetV2(try GameCenterLeaderboardSetV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetVersionsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetVersionsV2Response.swift
@@ -68,16 +68,18 @@ public struct GameCenterLeaderboardSetVersionsV2Response: Codable, Sendable, Pag
         case gameCenterLeaderboardSetV2(GameCenterLeaderboardSetV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardSetLocalizationV2 = try? GameCenterLeaderboardSetLocalizationV2(from: decoder) {
-                self = .gameCenterLeaderboardSetLocalizationV2(gameCenterLeaderboardSetLocalizationV2)
-            } else if let gameCenterLeaderboardSetV2 = try? GameCenterLeaderboardSetV2(from: decoder) {
-                self = .gameCenterLeaderboardSetV2(gameCenterLeaderboardSetV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardSetLocalizations":
+                self = .gameCenterLeaderboardSetLocalizationV2(try GameCenterLeaderboardSetLocalizationV2(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSetV2(try GameCenterLeaderboardSetV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetsResponse.swift
@@ -103,24 +103,26 @@ public struct GameCenterLeaderboardSetsResponse: Codable, Sendable, PagedRespons
         case gameCenterLeaderboardSetRelease(GameCenterLeaderboardSetRelease)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else if let gameCenterLeaderboardSetLocalization = try? GameCenterLeaderboardSetLocalization(from: decoder) {
-                self = .gameCenterLeaderboardSetLocalization(gameCenterLeaderboardSetLocalization)
-            } else if let gameCenterLeaderboardSetRelease = try? GameCenterLeaderboardSetRelease(from: decoder) {
-                self = .gameCenterLeaderboardSetRelease(gameCenterLeaderboardSetRelease)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            case "gameCenterLeaderboardSetLocalizations":
+                self = .gameCenterLeaderboardSetLocalization(try GameCenterLeaderboardSetLocalization(from: decoder))
+            case "gameCenterLeaderboardSetReleases":
+                self = .gameCenterLeaderboardSetRelease(try GameCenterLeaderboardSetRelease(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetsV2Response.swift
@@ -89,20 +89,22 @@ public struct GameCenterLeaderboardSetsV2Response: Codable, Sendable, PagedRespo
         case gameCenterLeaderboardV2(GameCenterLeaderboardV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboardSetVersionV2 = try? GameCenterLeaderboardSetVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardSetVersionV2(gameCenterLeaderboardSetVersionV2)
-            } else if let gameCenterLeaderboardV2 = try? GameCenterLeaderboardV2(from: decoder) {
-                self = .gameCenterLeaderboardV2(gameCenterLeaderboardV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboardSetVersions":
+                self = .gameCenterLeaderboardSetVersionV2(try GameCenterLeaderboardSetVersionV2(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboardV2(try GameCenterLeaderboardV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardV2Response.swift
@@ -98,24 +98,26 @@ public struct GameCenterLeaderboardV2Response: Codable, Sendable {
         case gameCenterLeaderboardVersionV2(GameCenterLeaderboardVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboardSetV2 = try? GameCenterLeaderboardSetV2(from: decoder) {
-                self = .gameCenterLeaderboardSetV2(gameCenterLeaderboardSetV2)
-            } else if let gameCenterLeaderboardVersionV2 = try? GameCenterLeaderboardVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardVersionV2(gameCenterLeaderboardVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSetV2(try GameCenterLeaderboardSetV2(from: decoder))
+            case "gameCenterLeaderboardVersions":
+                self = .gameCenterLeaderboardVersionV2(try GameCenterLeaderboardVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardVersionV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardVersionV2Response.swift
@@ -61,16 +61,18 @@ public struct GameCenterLeaderboardVersionV2Response: Codable, Sendable {
         case gameCenterLeaderboardV2(GameCenterLeaderboardV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardLocalizationV2 = try? GameCenterLeaderboardLocalizationV2(from: decoder) {
-                self = .gameCenterLeaderboardLocalizationV2(gameCenterLeaderboardLocalizationV2)
-            } else if let gameCenterLeaderboardV2 = try? GameCenterLeaderboardV2(from: decoder) {
-                self = .gameCenterLeaderboardV2(gameCenterLeaderboardV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardLocalizations":
+                self = .gameCenterLeaderboardLocalizationV2(try GameCenterLeaderboardLocalizationV2(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboardV2(try GameCenterLeaderboardV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardVersionsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardVersionsV2Response.swift
@@ -68,16 +68,18 @@ public struct GameCenterLeaderboardVersionsV2Response: Codable, Sendable, PagedR
         case gameCenterLeaderboardV2(GameCenterLeaderboardV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterLeaderboardLocalizationV2 = try? GameCenterLeaderboardLocalizationV2(from: decoder) {
-                self = .gameCenterLeaderboardLocalizationV2(gameCenterLeaderboardLocalizationV2)
-            } else if let gameCenterLeaderboardV2 = try? GameCenterLeaderboardV2(from: decoder) {
-                self = .gameCenterLeaderboardV2(gameCenterLeaderboardV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterLeaderboardLocalizations":
+                self = .gameCenterLeaderboardLocalizationV2(try GameCenterLeaderboardLocalizationV2(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboardV2(try GameCenterLeaderboardV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardsResponse.swift
@@ -119,28 +119,30 @@ public struct GameCenterLeaderboardsResponse: Codable, Sendable, PagedResponse {
         case gameCenterLeaderboardSet(GameCenterLeaderboardSet)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboard = try? GameCenterLeaderboard(from: decoder) {
-                self = .gameCenterLeaderboard(gameCenterLeaderboard)
-            } else if let gameCenterLeaderboardLocalization = try? GameCenterLeaderboardLocalization(from: decoder) {
-                self = .gameCenterLeaderboardLocalization(gameCenterLeaderboardLocalization)
-            } else if let gameCenterLeaderboardRelease = try? GameCenterLeaderboardRelease(from: decoder) {
-                self = .gameCenterLeaderboardRelease(gameCenterLeaderboardRelease)
-            } else if let gameCenterLeaderboardSet = try? GameCenterLeaderboardSet(from: decoder) {
-                self = .gameCenterLeaderboardSet(gameCenterLeaderboardSet)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboards":
+                self = .gameCenterLeaderboard(try GameCenterLeaderboard(from: decoder))
+            case "gameCenterLeaderboardLocalizations":
+                self = .gameCenterLeaderboardLocalization(try GameCenterLeaderboardLocalization(from: decoder))
+            case "gameCenterLeaderboardReleases":
+                self = .gameCenterLeaderboardRelease(try GameCenterLeaderboardRelease(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSet(try GameCenterLeaderboardSet(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardsV2Response.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardsV2Response.swift
@@ -105,24 +105,26 @@ public struct GameCenterLeaderboardsV2Response: Codable, Sendable, PagedResponse
         case gameCenterLeaderboardVersionV2(GameCenterLeaderboardVersionV2)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterActivity = try? GameCenterActivity(from: decoder) {
-                self = .gameCenterActivity(gameCenterActivity)
-            } else if let gameCenterChallenge = try? GameCenterChallenge(from: decoder) {
-                self = .gameCenterChallenge(gameCenterChallenge)
-            } else if let gameCenterDetail = try? GameCenterDetail(from: decoder) {
-                self = .gameCenterDetail(gameCenterDetail)
-            } else if let gameCenterGroup = try? GameCenterGroup(from: decoder) {
-                self = .gameCenterGroup(gameCenterGroup)
-            } else if let gameCenterLeaderboardSetV2 = try? GameCenterLeaderboardSetV2(from: decoder) {
-                self = .gameCenterLeaderboardSetV2(gameCenterLeaderboardSetV2)
-            } else if let gameCenterLeaderboardVersionV2 = try? GameCenterLeaderboardVersionV2(from: decoder) {
-                self = .gameCenterLeaderboardVersionV2(gameCenterLeaderboardVersionV2)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterActivities":
+                self = .gameCenterActivity(try GameCenterActivity(from: decoder))
+            case "gameCenterChallenges":
+                self = .gameCenterChallenge(try GameCenterChallenge(from: decoder))
+            case "gameCenterDetails":
+                self = .gameCenterDetail(try GameCenterDetail(from: decoder))
+            case "gameCenterGroups":
+                self = .gameCenterGroup(try GameCenterGroup(from: decoder))
+            case "gameCenterLeaderboardSets":
+                self = .gameCenterLeaderboardSetV2(try GameCenterLeaderboardSetV2(from: decoder))
+            case "gameCenterLeaderboardVersions":
+                self = .gameCenterLeaderboardVersionV2(try GameCenterLeaderboardVersionV2(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterMatchmakingRuleSetResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterMatchmakingRuleSetResponse.swift
@@ -81,18 +81,20 @@ public struct GameCenterMatchmakingRuleSetResponse: Codable, Sendable {
         case gameCenterMatchmakingTeam(GameCenterMatchmakingTeam)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterMatchmakingQueue = try? GameCenterMatchmakingQueue(from: decoder) {
-                self = .gameCenterMatchmakingQueue(gameCenterMatchmakingQueue)
-            } else if let gameCenterMatchmakingRule = try? GameCenterMatchmakingRule(from: decoder) {
-                self = .gameCenterMatchmakingRule(gameCenterMatchmakingRule)
-            } else if let gameCenterMatchmakingTeam = try? GameCenterMatchmakingTeam(from: decoder) {
-                self = .gameCenterMatchmakingTeam(gameCenterMatchmakingTeam)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterMatchmakingQueues":
+                self = .gameCenterMatchmakingQueue(try GameCenterMatchmakingQueue(from: decoder))
+            case "gameCenterMatchmakingRules":
+                self = .gameCenterMatchmakingRule(try GameCenterMatchmakingRule(from: decoder))
+            case "gameCenterMatchmakingTeams":
+                self = .gameCenterMatchmakingTeam(try GameCenterMatchmakingTeam(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterMatchmakingRuleSetTestResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterMatchmakingRuleSetTestResponse.swift
@@ -42,16 +42,18 @@ public struct GameCenterMatchmakingRuleSetTestResponse: Codable, Sendable {
         case gameCenterMatchmakingTestRequest(GameCenterMatchmakingTestRequest)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterMatchmakingTestPlayerProperty = try? GameCenterMatchmakingTestPlayerProperty(from: decoder) {
-                self = .gameCenterMatchmakingTestPlayerProperty(gameCenterMatchmakingTestPlayerProperty)
-            } else if let gameCenterMatchmakingTestRequest = try? GameCenterMatchmakingTestRequest(from: decoder) {
-                self = .gameCenterMatchmakingTestRequest(gameCenterMatchmakingTestRequest)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterMatchmakingTestPlayerProperties":
+                self = .gameCenterMatchmakingTestPlayerProperty(try GameCenterMatchmakingTestPlayerProperty(from: decoder))
+            case "gameCenterMatchmakingTestRequests":
+                self = .gameCenterMatchmakingTestRequest(try GameCenterMatchmakingTestRequest(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterMatchmakingRuleSetsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterMatchmakingRuleSetsResponse.swift
@@ -88,18 +88,20 @@ public struct GameCenterMatchmakingRuleSetsResponse: Codable, Sendable, PagedRes
         case gameCenterMatchmakingTeam(GameCenterMatchmakingTeam)
 
         public init(from decoder: Decoder) throws {
-            if let gameCenterMatchmakingQueue = try? GameCenterMatchmakingQueue(from: decoder) {
-                self = .gameCenterMatchmakingQueue(gameCenterMatchmakingQueue)
-            } else if let gameCenterMatchmakingRule = try? GameCenterMatchmakingRule(from: decoder) {
-                self = .gameCenterMatchmakingRule(gameCenterMatchmakingRule)
-            } else if let gameCenterMatchmakingTeam = try? GameCenterMatchmakingTeam(from: decoder) {
-                self = .gameCenterMatchmakingTeam(gameCenterMatchmakingTeam)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "gameCenterMatchmakingQueues":
+                self = .gameCenterMatchmakingQueue(try GameCenterMatchmakingQueue(from: decoder))
+            case "gameCenterMatchmakingRules":
+                self = .gameCenterMatchmakingRule(try GameCenterMatchmakingRule(from: decoder))
+            case "gameCenterMatchmakingTeams":
+                self = .gameCenterMatchmakingTeam(try GameCenterMatchmakingTeam(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-Marketplaces/Models/AlternativeDistributionPackageVersionResponse.swift
+++ b/Sources/Bagbutik-Marketplaces/Models/AlternativeDistributionPackageVersionResponse.swift
@@ -79,18 +79,20 @@ public struct AlternativeDistributionPackageVersionResponse: Codable, Sendable {
         case alternativeDistributionPackageVariant(AlternativeDistributionPackageVariant)
 
         public init(from decoder: Decoder) throws {
-            if let alternativeDistributionPackage = try? AlternativeDistributionPackage(from: decoder) {
-                self = .alternativeDistributionPackage(alternativeDistributionPackage)
-            } else if let alternativeDistributionPackageDelta = try? AlternativeDistributionPackageDelta(from: decoder) {
-                self = .alternativeDistributionPackageDelta(alternativeDistributionPackageDelta)
-            } else if let alternativeDistributionPackageVariant = try? AlternativeDistributionPackageVariant(from: decoder) {
-                self = .alternativeDistributionPackageVariant(alternativeDistributionPackageVariant)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "alternativeDistributionPackages":
+                self = .alternativeDistributionPackage(try AlternativeDistributionPackage(from: decoder))
+            case "alternativeDistributionPackageDeltas":
+                self = .alternativeDistributionPackageDelta(try AlternativeDistributionPackageDelta(from: decoder))
+            case "alternativeDistributionPackageVariants":
+                self = .alternativeDistributionPackageVariant(try AlternativeDistributionPackageVariant(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-Marketplaces/Models/AlternativeDistributionPackageVersionsResponse.swift
+++ b/Sources/Bagbutik-Marketplaces/Models/AlternativeDistributionPackageVersionsResponse.swift
@@ -86,18 +86,20 @@ public struct AlternativeDistributionPackageVersionsResponse: Codable, Sendable,
         case alternativeDistributionPackageVariant(AlternativeDistributionPackageVariant)
 
         public init(from decoder: Decoder) throws {
-            if let alternativeDistributionPackage = try? AlternativeDistributionPackage(from: decoder) {
-                self = .alternativeDistributionPackage(alternativeDistributionPackage)
-            } else if let alternativeDistributionPackageDelta = try? AlternativeDistributionPackageDelta(from: decoder) {
-                self = .alternativeDistributionPackageDelta(alternativeDistributionPackageDelta)
-            } else if let alternativeDistributionPackageVariant = try? AlternativeDistributionPackageVariant(from: decoder) {
-                self = .alternativeDistributionPackageVariant(alternativeDistributionPackageVariant)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "alternativeDistributionPackages":
+                self = .alternativeDistributionPackage(try AlternativeDistributionPackage(from: decoder))
+            case "alternativeDistributionPackageDeltas":
+                self = .alternativeDistributionPackageDelta(try AlternativeDistributionPackageDelta(from: decoder))
+            case "alternativeDistributionPackageVariants":
+                self = .alternativeDistributionPackageVariant(try AlternativeDistributionPackageVariant(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-Provisioning/Models/BundleIdResponse.swift
+++ b/Sources/Bagbutik-Provisioning/Models/BundleIdResponse.swift
@@ -77,18 +77,20 @@ public struct BundleIdResponse: Codable, Sendable {
         case profile(Profile)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let bundleIdCapability = try? BundleIdCapability(from: decoder) {
-                self = .bundleIdCapability(bundleIdCapability)
-            } else if let profile = try? Profile(from: decoder) {
-                self = .profile(profile)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "bundleIdCapabilities":
+                self = .bundleIdCapability(try BundleIdCapability(from: decoder))
+            case "profiles":
+                self = .profile(try Profile(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-Provisioning/Models/BundleIdsResponse.swift
+++ b/Sources/Bagbutik-Provisioning/Models/BundleIdsResponse.swift
@@ -85,18 +85,20 @@ public struct BundleIdsResponse: Codable, Sendable, PagedResponse {
         case profile(Profile)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let bundleIdCapability = try? BundleIdCapability(from: decoder) {
-                self = .bundleIdCapability(bundleIdCapability)
-            } else if let profile = try? Profile(from: decoder) {
-                self = .profile(profile)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "bundleIdCapabilities":
+                self = .bundleIdCapability(try BundleIdCapability(from: decoder))
+            case "profiles":
+                self = .profile(try Profile(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-Provisioning/Models/ProfileResponse.swift
+++ b/Sources/Bagbutik-Provisioning/Models/ProfileResponse.swift
@@ -76,18 +76,20 @@ public struct ProfileResponse: Codable, Sendable {
         case device(Device)
 
         public init(from decoder: Decoder) throws {
-            if let bundleId = try? BundleId(from: decoder) {
-                self = .bundleId(bundleId)
-            } else if let certificate = try? Certificate(from: decoder) {
-                self = .certificate(certificate)
-            } else if let device = try? Device(from: decoder) {
-                self = .device(device)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "bundleIds":
+                self = .bundleId(try BundleId(from: decoder))
+            case "certificates":
+                self = .certificate(try Certificate(from: decoder))
+            case "devices":
+                self = .device(try Device(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-Provisioning/Models/ProfilesResponse.swift
+++ b/Sources/Bagbutik-Provisioning/Models/ProfilesResponse.swift
@@ -84,18 +84,20 @@ public struct ProfilesResponse: Codable, Sendable, PagedResponse {
         case device(Device)
 
         public init(from decoder: Decoder) throws {
-            if let bundleId = try? BundleId(from: decoder) {
-                self = .bundleId(bundleId)
-            } else if let certificate = try? Certificate(from: decoder) {
-                self = .certificate(certificate)
-            } else if let device = try? Device(from: decoder) {
-                self = .device(device)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "bundleIds":
+                self = .bundleId(try BundleId(from: decoder))
+            case "certificates":
+                self = .certificate(try Certificate(from: decoder))
+            case "devices":
+                self = .device(try Device(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaFeedbackCrashSubmissionResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaFeedbackCrashSubmissionResponse.swift
@@ -56,16 +56,18 @@ public struct BetaFeedbackCrashSubmissionResponse: Codable, Sendable {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaFeedbackCrashSubmissionsResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaFeedbackCrashSubmissionsResponse.swift
@@ -63,16 +63,18 @@ public struct BetaFeedbackCrashSubmissionsResponse: Codable, Sendable, PagedResp
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaFeedbackScreenshotSubmissionResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaFeedbackScreenshotSubmissionResponse.swift
@@ -56,16 +56,18 @@ public struct BetaFeedbackScreenshotSubmissionResponse: Codable, Sendable {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaFeedbackScreenshotSubmissionsResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaFeedbackScreenshotSubmissionsResponse.swift
@@ -56,16 +56,18 @@ public struct BetaFeedbackScreenshotSubmissionsResponse: Codable, Sendable, Page
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaGroupResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaGroupResponse.swift
@@ -84,20 +84,22 @@ public struct BetaGroupResponse: Codable, Sendable {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let betaRecruitmentCriterion = try? BetaRecruitmentCriterion(from: decoder) {
-                self = .betaRecruitmentCriterion(betaRecruitmentCriterion)
-            } else if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "betaRecruitmentCriteria":
+                self = .betaRecruitmentCriterion(try BetaRecruitmentCriterion(from: decoder))
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaGroupsResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaGroupsResponse.swift
@@ -92,20 +92,22 @@ public struct BetaGroupsResponse: Codable, Sendable, PagedResponse {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let betaRecruitmentCriterion = try? BetaRecruitmentCriterion(from: decoder) {
-                self = .betaRecruitmentCriterion(betaRecruitmentCriterion)
-            } else if let betaTester = try? BetaTester(from: decoder) {
-                self = .betaTester(betaTester)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "betaRecruitmentCriteria":
+                self = .betaRecruitmentCriterion(try BetaRecruitmentCriterion(from: decoder))
+            case "betaTesters":
+                self = .betaTester(try BetaTester(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaTesterResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaTesterResponse.swift
@@ -81,18 +81,20 @@ public struct BetaTesterResponse: Codable, Sendable {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let betaGroup = try? BetaGroup(from: decoder) {
-                self = .betaGroup(betaGroup)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "betaGroups":
+                self = .betaGroup(try BetaGroup(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/BetaTestersResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/BetaTestersResponse.swift
@@ -89,18 +89,20 @@ public struct BetaTestersResponse: Codable, Sendable, PagedResponse {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let betaGroup = try? BetaGroup(from: decoder) {
-                self = .betaGroup(betaGroup)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "betaGroups":
+                self = .betaGroup(try BetaGroup(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/PreReleaseVersionsResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/PreReleaseVersionsResponse.swift
@@ -71,16 +71,18 @@ public struct PreReleaseVersionsResponse: Codable, Sendable, PagedResponse {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-TestFlight/Models/PrereleaseVersionResponse.swift
+++ b/Sources/Bagbutik-TestFlight/Models/PrereleaseVersionResponse.swift
@@ -63,16 +63,18 @@ public struct PrereleaseVersionResponse: Codable, Sendable {
         case build(Build)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "builds":
+                self = .build(try Build(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/CiBuildRunResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/CiBuildRunResponse.swift
@@ -95,22 +95,24 @@ public struct CiBuildRunResponse: Codable, Sendable {
         case scmPullRequest(ScmPullRequest)
 
         public init(from decoder: Decoder) throws {
-            if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let ciProduct = try? CiProduct(from: decoder) {
-                self = .ciProduct(ciProduct)
-            } else if let ciWorkflow = try? CiWorkflow(from: decoder) {
-                self = .ciWorkflow(ciWorkflow)
-            } else if let scmGitReference = try? ScmGitReference(from: decoder) {
-                self = .scmGitReference(scmGitReference)
-            } else if let scmPullRequest = try? ScmPullRequest(from: decoder) {
-                self = .scmPullRequest(scmPullRequest)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "ciProducts":
+                self = .ciProduct(try CiProduct(from: decoder))
+            case "ciWorkflows":
+                self = .ciWorkflow(try CiWorkflow(from: decoder))
+            case "scmGitReferences":
+                self = .scmGitReference(try ScmGitReference(from: decoder))
+            case "scmPullRequests":
+                self = .scmPullRequest(try ScmPullRequest(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/CiBuildRunsResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/CiBuildRunsResponse.swift
@@ -103,22 +103,24 @@ public struct CiBuildRunsResponse: Codable, Sendable, PagedResponse {
         case scmPullRequest(ScmPullRequest)
 
         public init(from decoder: Decoder) throws {
-            if let build = try? Build(from: decoder) {
-                self = .build(build)
-            } else if let ciProduct = try? CiProduct(from: decoder) {
-                self = .ciProduct(ciProduct)
-            } else if let ciWorkflow = try? CiWorkflow(from: decoder) {
-                self = .ciWorkflow(ciWorkflow)
-            } else if let scmGitReference = try? ScmGitReference(from: decoder) {
-                self = .scmGitReference(scmGitReference)
-            } else if let scmPullRequest = try? ScmPullRequest(from: decoder) {
-                self = .scmPullRequest(scmPullRequest)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "builds":
+                self = .build(try Build(from: decoder))
+            case "ciProducts":
+                self = .ciProduct(try CiProduct(from: decoder))
+            case "ciWorkflows":
+                self = .ciWorkflow(try CiWorkflow(from: decoder))
+            case "scmGitReferences":
+                self = .scmGitReference(try ScmGitReference(from: decoder))
+            case "scmPullRequests":
+                self = .scmPullRequest(try ScmPullRequest(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/CiProductResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/CiProductResponse.swift
@@ -72,18 +72,20 @@ public struct CiProductResponse: Codable, Sendable {
         case scmRepository(ScmRepository)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let bundleId = try? BundleId(from: decoder) {
-                self = .bundleId(bundleId)
-            } else if let scmRepository = try? ScmRepository(from: decoder) {
-                self = .scmRepository(scmRepository)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "bundleIds":
+                self = .bundleId(try BundleId(from: decoder))
+            case "scmRepositories":
+                self = .scmRepository(try ScmRepository(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/CiProductsResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/CiProductsResponse.swift
@@ -80,18 +80,20 @@ public struct CiProductsResponse: Codable, Sendable, PagedResponse {
         case scmRepository(ScmRepository)
 
         public init(from decoder: Decoder) throws {
-            if let app = try? App(from: decoder) {
-                self = .app(app)
-            } else if let bundleId = try? BundleId(from: decoder) {
-                self = .bundleId(bundleId)
-            } else if let scmRepository = try? ScmRepository(from: decoder) {
-                self = .scmRepository(scmRepository)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "apps":
+                self = .app(try App(from: decoder))
+            case "bundleIds":
+                self = .bundleId(try BundleId(from: decoder))
+            case "scmRepositories":
+                self = .scmRepository(try ScmRepository(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/CiWorkflowResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/CiWorkflowResponse.swift
@@ -75,20 +75,22 @@ public struct CiWorkflowResponse: Codable, Sendable {
         case scmRepository(ScmRepository)
 
         public init(from decoder: Decoder) throws {
-            if let ciMacOsVersion = try? CiMacOsVersion(from: decoder) {
-                self = .ciMacOsVersion(ciMacOsVersion)
-            } else if let ciProduct = try? CiProduct(from: decoder) {
-                self = .ciProduct(ciProduct)
-            } else if let ciXcodeVersion = try? CiXcodeVersion(from: decoder) {
-                self = .ciXcodeVersion(ciXcodeVersion)
-            } else if let scmRepository = try? ScmRepository(from: decoder) {
-                self = .scmRepository(scmRepository)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "ciMacOsVersions":
+                self = .ciMacOsVersion(try CiMacOsVersion(from: decoder))
+            case "ciProducts":
+                self = .ciProduct(try CiProduct(from: decoder))
+            case "ciXcodeVersions":
+                self = .ciXcodeVersion(try CiXcodeVersion(from: decoder))
+            case "scmRepositories":
+                self = .scmRepository(try ScmRepository(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/CiWorkflowsResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/CiWorkflowsResponse.swift
@@ -83,20 +83,22 @@ public struct CiWorkflowsResponse: Codable, Sendable, PagedResponse {
         case scmRepository(ScmRepository)
 
         public init(from decoder: Decoder) throws {
-            if let ciMacOsVersion = try? CiMacOsVersion(from: decoder) {
-                self = .ciMacOsVersion(ciMacOsVersion)
-            } else if let ciProduct = try? CiProduct(from: decoder) {
-                self = .ciProduct(ciProduct)
-            } else if let ciXcodeVersion = try? CiXcodeVersion(from: decoder) {
-                self = .ciXcodeVersion(ciXcodeVersion)
-            } else if let scmRepository = try? ScmRepository(from: decoder) {
-                self = .scmRepository(scmRepository)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "ciMacOsVersions":
+                self = .ciMacOsVersion(try CiMacOsVersion(from: decoder))
+            case "ciProducts":
+                self = .ciProduct(try CiProduct(from: decoder))
+            case "ciXcodeVersions":
+                self = .ciXcodeVersion(try CiXcodeVersion(from: decoder))
+            case "scmRepositories":
+                self = .scmRepository(try ScmRepository(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/ScmRepositoriesResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/ScmRepositoriesResponse.swift
@@ -67,16 +67,18 @@ public struct ScmRepositoriesResponse: Codable, Sendable, PagedResponse {
         case scmProvider(ScmProvider)
 
         public init(from decoder: Decoder) throws {
-            if let scmGitReference = try? ScmGitReference(from: decoder) {
-                self = .scmGitReference(scmGitReference)
-            } else if let scmProvider = try? ScmProvider(from: decoder) {
-                self = .scmProvider(scmProvider)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "scmGitReferences":
+                self = .scmGitReference(try ScmGitReference(from: decoder))
+            case "scmProviders":
+                self = .scmProvider(try ScmProvider(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/Bagbutik-XcodeCloud/Models/ScmRepositoryResponse.swift
+++ b/Sources/Bagbutik-XcodeCloud/Models/ScmRepositoryResponse.swift
@@ -59,16 +59,18 @@ public struct ScmRepositoryResponse: Codable, Sendable {
         case scmProvider(ScmProvider)
 
         public init(from decoder: Decoder) throws {
-            if let scmGitReference = try? ScmGitReference(from: decoder) {
-                self = .scmGitReference(scmGitReference)
-            } else if let scmProvider = try? ScmProvider(from: decoder) {
-                self = .scmProvider(scmProvider)
-            } else {
-                throw DecodingError.typeMismatch(
-                    Included.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Unknown Included"))
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "type")
+            switch discriminatorValue {
+            case "scmGitReferences":
+                self = .scmGitReference(try ScmGitReference(from: decoder))
+            case "scmProviders":
+                self = .scmProvider(try ScmProvider(from: decoder))
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "type",
+                    in: container,
+                    debugDescription: "Unknown Included type '\(discriminatorValue)'")
             }
         }
 

--- a/Sources/BagbutikGenerator/Renderers/OneOfSchemaRenderer.swift
+++ b/Sources/BagbutikGenerator/Renderers/OneOfSchemaRenderer.swift
@@ -21,7 +21,77 @@ public class OneOfSchemaRenderer: Renderer {
         }
 
         var enumContent = [String]()
-        enumContent.append(renderInitializer(parameters: [.init(prefix: "from", name: "decoder", type: "Decoder")], throwing: true, content: {
+        if let discriminator = oneOfSchema.discriminator,
+           let discriminatorCases = createDiscriminatorCases(for: options, discriminator: discriminator) {
+            enumContent.append(renderDiscriminatorInitializer(name: name, discriminator: discriminator, discriminatorCases: discriminatorCases))
+        } else {
+            enumContent.append(renderFallbackInitializer(name: name, options: options))
+        }
+        enumContent.append(renderFunction(named: "encode", parameters: [.init(prefix: "to", name: "encoder", type: "Encoder")], throwing: true, content: {
+            var rendered = "switch self {\n"
+            rendered += options.map { option in
+                """
+                case let .\(option.id)(value):
+                    try value.encode(to: encoder)
+                """
+            }.joined(separator: "\n")
+            rendered += "\n}"
+            return rendered
+        }))
+        let objectRenderer = ObjectSchemaRenderer(docsLoader: docsLoader, shouldFormat: false)
+        for subSchema in subSchemas {
+            try await enumContent.append(objectRenderer.render(objectSchema: subSchema, otherSchemas: [:]))
+        }
+        let protocols = ["Codable", "Sendable"] + oneOfSchema.additionalProtocols
+        return renderEnum(named: name,
+                          protocols: protocols,
+                          cases: options,
+                          caseValueIsAssociated: true,
+                          content: enumContent.joined(separator: "\n\n"))
+    }
+
+    private func createDiscriminatorCases(for options: [EnumCase], discriminator: Discriminator) -> [DiscriminatorCase]? {
+        guard !discriminator.mapping.isEmpty else { return nil }
+        let discriminatorCases = options.compactMap { option -> DiscriminatorCase? in
+            let matchingValues = discriminator.mapping.compactMap { value, schemaRef -> String? in
+                let schemaName = schemaRef.components(separatedBy: "/").last ?? schemaRef
+                return schemaName == option.value ? value : nil
+            }
+            guard let discriminatorValue = matchingValues.sorted().first else { return nil }
+            return DiscriminatorCase(id: option.id, type: option.value, discriminatorValue: discriminatorValue)
+        }
+        return discriminatorCases.count == options.count ? discriminatorCases : nil
+    }
+
+    private func renderDiscriminatorInitializer(name: String, discriminator: Discriminator, discriminatorCases: [DiscriminatorCase]) -> String {
+        renderInitializer(parameters: [.init(prefix: "from", name: "decoder", type: "Decoder")], throwing: true, content: {
+            var rendered = """
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            let discriminatorValue = try container.decode(String.self, forKey: "\(discriminator.propertyName)")
+            switch discriminatorValue {
+
+            """
+            rendered += discriminatorCases.map { discriminatorCase in
+                """
+                case "\(discriminatorCase.discriminatorValue)":
+                    self = .\(discriminatorCase.id)(try \(discriminatorCase.type)(from: decoder))
+                """
+            }.joined(separator: "\n")
+            rendered += """
+
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: "\(discriminator.propertyName)",
+                    in: container,
+                    debugDescription: "Unknown \(name) \(discriminator.propertyName) '\\(discriminatorValue)'")
+            }
+            """
+            return rendered
+        })
+    }
+
+    private func renderFallbackInitializer(name: String, options: [EnumCase]) -> String {
+        renderInitializer(parameters: [.init(prefix: "from", name: "decoder", type: "Decoder")], throwing: true, content: {
             var rendered = ""
             for item in options.enumerated() {
                 let option = item.element
@@ -46,27 +116,12 @@ public class OneOfSchemaRenderer: Renderer {
             }
             """
             return rendered
-        }))
-        enumContent.append(renderFunction(named: "encode", parameters: [.init(prefix: "to", name: "encoder", type: "Encoder")], throwing: true, content: {
-            var rendered = "switch self {\n"
-            rendered += options.map { option in
-                """
-                case let .\(option.id)(value):
-                    try value.encode(to: encoder)
-                """
-            }.joined(separator: "\n")
-            rendered += "\n}"
-            return rendered
-        }))
-        let objectRenderer = ObjectSchemaRenderer(docsLoader: docsLoader, shouldFormat: false)
-        for subSchema in subSchemas {
-            try await enumContent.append(objectRenderer.render(objectSchema: subSchema, otherSchemas: [:]))
-        }
-        let protocols = ["Codable", "Sendable"] + oneOfSchema.additionalProtocols
-        return renderEnum(named: name,
-                          protocols: protocols,
-                          cases: options,
-                          caseValueIsAssociated: true,
-                          content: enumContent.joined(separator: "\n\n"))
+        })
+    }
+
+    private struct DiscriminatorCase {
+        let id: String
+        let type: String
+        let discriminatorValue: String
     }
 }

--- a/Sources/BagbutikSpecDecoder/Schemas/OneOfSchema.swift
+++ b/Sources/BagbutikSpecDecoder/Schemas/OneOfSchema.swift
@@ -4,6 +4,8 @@ import Foundation
 public struct OneOfSchema: Decodable, Equatable, Sendable {
     /// The options/cases of the schema
     public var options: [OneOfOption]
+    /// The discriminator used to select an option when decoding
+    public var discriminator: Discriminator?
     /// Additional protocols the enum should have when rendered
     public var additionalProtocols: Set<String>
     
@@ -12,10 +14,41 @@ public struct OneOfSchema: Decodable, Equatable, Sendable {
 
      - Parameters:
         - options: The options/cases of the schema
+        - discriminator: The discriminator used to select an option when decoding
         - additionalProtocols: Additional protocols the enum should have when rendered
      */
-    init(options: [OneOfOption], additionalProtocols: [String] = []) {
-        self.options = options
+    init(options: [OneOfOption], discriminator: Discriminator? = nil, additionalProtocols: [String] = []) {
+        self.options = options.reduce(into: [OneOfOption]()) { uniqueOptions, option in
+            if !uniqueOptions.contains(option) {
+                uniqueOptions.append(option)
+            }
+        }
+        self.discriminator = discriminator
         self.additionalProtocols = Set(additionalProtocols)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case oneOf
+        case discriminator
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let options = try container.decode([OneOfOption].self, forKey: .oneOf)
+        let discriminator = try container.decodeIfPresent(Discriminator.self, forKey: .discriminator)
+        self.init(options: options, discriminator: discriminator)
+    }
+}
+
+/// A discriminator for selecting an option from a one of schema
+public struct Discriminator: Decodable, Equatable, Sendable {
+    /// The name of the property which holds the discriminator value
+    public let propertyName: String
+    /// A mapping from discriminator values to schema references
+    public let mapping: [String: String]
+
+    public init(propertyName: String, mapping: [String: String]) {
+        self.propertyName = propertyName
+        self.mapping = mapping
     }
 }

--- a/Sources/BagbutikSpecDecoder/Schemas/PropertyType.swift
+++ b/Sources/BagbutikSpecDecoder/Schemas/PropertyType.swift
@@ -86,16 +86,11 @@ public indirect enum PropertyType: Decodable, Equatable, CustomStringConvertible
         let container = try decoder.container(keyedBy: CodingKeys.self)
         if var type = try container.decodeIfPresent(String.self, forKey: .type) {
             if type == "array" {
-                if let oneOfOptions = try container
-                    .nestedContainer(keyedBy: CodingKeys.self, forKey: .items)
-                    .decodeIfPresent([OneOfOption].self, forKey: .oneOf)?
-                    .reduce(into: [OneOfOption](), { uniqueOptions, option in
-                        if !uniqueOptions.contains(option) {
-                            uniqueOptions.append(option)
-                        }
-                    }),
-                    let oneOfName = container.codingPath.last?.stringValue.capitalizingFirstLetter() {
-                    self = .arrayOfOneOf(name: oneOfName, schema: OneOfSchema(options: oneOfOptions))
+                let itemsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .items)
+                if itemsContainer.contains(.oneOf),
+                   let oneOfName = container.codingPath.last?.stringValue.capitalizingFirstLetter() {
+                    let oneOfSchema = try container.decode(OneOfSchema.self, forKey: .items)
+                    self = .arrayOfOneOf(name: oneOfName, schema: oneOfSchema)
                 } else if case .schemaRef(let schemaName) = try? container.decodeIfPresent(PropertyType.self, forKey: .items) {
                     self = .arrayOfSchemaRef(schemaName)
                 } else if let schema = try? container.decodeIfPresent(ObjectSchema.self, forKey: .items),
@@ -139,9 +134,10 @@ public indirect enum PropertyType: Decodable, Equatable, CustomStringConvertible
             } else {
                 self = .schemaRef(schemaName)
             }
-        } else if let oneOfOptions = try container.decodeIfPresent([OneOfOption].self, forKey: .oneOf),
+        } else if container.contains(.oneOf),
                   let oneOfName = container.codingPath.last?.stringValue.capitalizingFirstLetter() {
-            self = .oneOf(name: oneOfName, schema: OneOfSchema(options: oneOfOptions))
+            let oneOfSchema = try OneOfSchema(from: decoder)
+            self = .oneOf(name: oneOfName, schema: oneOfSchema)
         } else if container.codingPath.last?.stringValue == "additionalProperties" {
             self = .simple(.string())
         } else {

--- a/Tests/BagbutikGeneratorTests/Renderers/OneOfSchemaRendererTests.swift
+++ b/Tests/BagbutikGeneratorTests/Renderers/OneOfSchemaRendererTests.swift
@@ -145,4 +145,50 @@ final class OneOfSchemaRendererTests: XCTestCase {
         }
         """#)
     }
+
+    func testRenderWithDiscriminator() async throws {
+        // Given
+        let docsLoader = DocsLoader(schemaDocumentationById: [:])
+        let renderer = OneOfSchemaRenderer(docsLoader: docsLoader, shouldFormat: true)
+        let schema = OneOfSchema(
+            options: [.schemaRef("BundleId"), .schemaRef("App")],
+            discriminator: .init(propertyName: "type", mapping: [
+                "bundleIds": "#/components/schemas/BundleId",
+                "apps": "#/components/schemas/App"
+            ]))
+        // When
+        let rendered = try await renderer.render(name: "Included", oneOfSchema: schema)
+        // Then
+        XCTAssertEqual(rendered, #"""
+        public enum Included: Codable, Sendable {
+            case app(App)
+            case bundleId(BundleId)
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: AnyCodingKey.self)
+                let discriminatorValue = try container.decode(String.self, forKey: "type")
+                switch discriminatorValue {
+                case "apps":
+                    self = .app(try App(from: decoder))
+                case "bundleIds":
+                    self = .bundleId(try BundleId(from: decoder))
+                default:
+                    throw DecodingError.dataCorruptedError(
+                        forKey: "type",
+                        in: container,
+                        debugDescription: "Unknown Included type '\(discriminatorValue)'")
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                switch self {
+                case let .app(value):
+                    try value.encode(to: encoder)
+                case let .bundleId(value):
+                    try value.encode(to: encoder)
+                }
+            }
+        }
+        """#)
+    }
 }

--- a/Tests/BagbutikSpecDecoderTests/Schemas/PropertyTypeTests.swift
+++ b/Tests/BagbutikSpecDecoderTests/Schemas/PropertyTypeTests.swift
@@ -199,6 +199,45 @@ final class PropertyTypeTests: XCTestCase {
         XCTAssertEqual(propertyType.description, "[ArrayOfOneOfSchemas]")
         XCTAssertEqual(name, "ArrayOfOneOfSchemas")
     }
+
+    func testDecodingArrayOfOneOfWithDiscriminator() throws {
+        // Given
+        let json = #"""
+        {
+            "included" : {
+                "type" : "array",
+                "items" : {
+                    "oneOf" : [ {
+                        "$ref" : "#/components/schemas/App"
+                    }, {
+                        "$ref" : "#/components/schemas/Build"
+                    } ],
+                    "discriminator" : {
+                        "propertyName" : "type",
+                        "mapping" : {
+                            "apps" : "#/components/schemas/App",
+                            "builds" : "#/components/schemas/Build"
+                        }
+                    }
+                }
+            }
+        }
+        """#
+        // When
+        let propertyTypes = try jsonDecoder.decode([String: PropertyType].self, from: json.data(using: .utf8)!)
+        // Then
+        guard let propertyType = propertyTypes.values.first, case let .arrayOfOneOf(name, schema) = propertyType else {
+            return XCTFail("Wrong property type")
+        }
+        XCTAssertEqual(name, "Included")
+        XCTAssertEqual(schema.options, [.schemaRef("App"), .schemaRef("Build")])
+        XCTAssertEqual(schema.discriminator, Discriminator(
+            propertyName: "type",
+            mapping: [
+                "apps": "#/components/schemas/App",
+                "builds": "#/components/schemas/Build"
+            ]))
+    }
     
     func testDecodingDictionaryOfDictionaries() throws {
         // Given


### PR DESCRIPTION
When responses contains a `discriminator` we can use that for faster decoding.