### PR TITLE
Fix docs abstract reference decoding

### DIFF
--- a/Sources/BagbutikDocsCollector/Models/Documentation.swift
+++ b/Sources/BagbutikDocsCollector/Models/Documentation.swift
@@ -111,7 +111,7 @@ public enum Documentation: Codable, Equatable, Sendable {
                 return "[\(reference.title)](\(reference.url))"
             }
         }
-        let abstract = try container.decodeIfPresent([Abstract].self, forKey: .abstract)?.reduce(into: "") { partialResult, abstract in
+        let abstract = try container.decodeIfPresent([DecodedAbstract].self, forKey: .abstract)?.reduce(into: "") { partialResult, abstract in
             switch abstract {
             case .text(let text):
                 partialResult.append(text)
@@ -232,7 +232,7 @@ public enum Documentation: Codable, Equatable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(Identifier(url: id), forKey: .identifier)
         if let abstract {
-            try container.encode([Abstract(text: abstract)], forKey: .abstract)
+            try container.encode([EncodedAbstract(text: abstract)], forKey: .abstract)
         }
         try container.encode(hierarchy, forKey: .hierarchy)
         var contentSections = [ContentSection]()
@@ -296,14 +296,10 @@ public enum Documentation: Codable, Equatable, Sendable {
         let symbolKind: String
     }
 
-    private enum Abstract: Codable {
+    private enum DecodedAbstract: Decodable {
         case text(String)
         case code(String)
         case reference(String)
-        
-        init(text: String) {
-            self = .text(text)
-        }
 
         init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -319,25 +315,25 @@ public enum Documentation: Codable, Equatable, Sendable {
             }
         }
 
-        func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            switch self {
-            case .text(let text):
-                try container.encode("text", forKey: .type)
-                try container.encode(text, forKey: .text)
-            case .code(let code):
-                try container.encode("codeVoice", forKey: .type)
-                try container.encode(code, forKey: .code)
-            case .reference(let identifier):
-                try container.encode("reference", forKey: .type)
-                try container.encode(identifier, forKey: .identifier)
-            }
-        }
-
         enum CodingKeys: CodingKey {
             case text
             case code
             case identifier
+            case type
+        }
+    }
+
+    private struct EncodedAbstract: Encodable {
+        let text: String
+
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("text", forKey: .type)
+            try container.encode(text, forKey: .text)
+        }
+
+        enum CodingKeys: CodingKey {
+            case text
             case type
         }
     }

--- a/Sources/BagbutikDocsCollector/Models/Documentation.swift
+++ b/Sources/BagbutikDocsCollector/Models/Documentation.swift
@@ -98,24 +98,38 @@ public enum Documentation: Codable, Equatable, Sendable {
         let id = try container.decode(Identifier.self, forKey: .identifier).url
         let hierarchy = try container.decode(Hierarchy.self, forKey: .hierarchy)
         let metadata = try container.decode(Metadata.self, forKey: .metadata)
-        let abstract = try container.decodeIfPresent([Abstract].self, forKey: .abstract)?.map(\.text).joined()
         let references = try container.decodeIfPresent([String: Reference].self, forKey: .references)
+        let formatReference: (String) -> String? = { identifier in
+            guard let reference = references?[identifier] else { return nil }
+            switch reference.role {
+            case .dictionarySymbol:
+                let formattedReference = reference.title
+                    .replacingOccurrences(of: ".", with: "/")
+                    .capitalizingFirstLetter()
+                return "``\(formattedReference)``"
+            case .symbol, .article, .link, .none:
+                return "[\(reference.title)](\(reference.url))"
+            }
+        }
+        let abstract = try container.decodeIfPresent([Abstract].self, forKey: .abstract)?.reduce(into: "") { partialResult, abstract in
+            switch abstract {
+            case .text(let text):
+                partialResult.append(text)
+            case .code(let code):
+                partialResult.append(code)
+            case .reference(let identifier):
+                guard let reference = formatReference(identifier) else { return }
+                partialResult.append(reference)
+            }
+        }
         let formatContent: (Content?) -> String? = { content in
             content?.inlineContent.reduce(into: "") { contentResult, inlineContent in
                 switch inlineContent {
                 case .text(let text):
                     contentResult.append(text)
                 case .reference(let identifier):
-                    guard let reference = references?[identifier] else { return }
-                    switch reference.role {
-                    case .dictionarySymbol:
-                        let formattedReference = reference.title
-                            .replacingOccurrences(of: ".", with: "/")
-                            .capitalizingFirstLetter()
-                        contentResult.append("``\(formattedReference)``")
-                    case .symbol, .article, .link, .none:
-                        contentResult.append("[\(reference.title)](\(reference.url))")
-                    }
+                    guard let reference = formatReference(identifier) else { return }
+                    contentResult.append(reference)
                 }
             }
         }
@@ -285,13 +299,7 @@ public enum Documentation: Codable, Equatable, Sendable {
     private enum Abstract: Codable {
         case text(String)
         case code(String)
-
-        var text: String {
-            switch self {
-            case .text(let text): text
-            case .code(let code): code
-            }
-        }
+        case reference(String)
         
         init(text: String) {
             self = .text(text)
@@ -304,6 +312,8 @@ public enum Documentation: Codable, Equatable, Sendable {
                 self = try .text(container.decode(String.self, forKey: .text))
             } else if type == "codeVoice" {
                 self = try .code(container.decode(String.self, forKey: .code))
+            } else if type == "reference" {
+                self = try .reference(container.decode(String.self, forKey: .identifier))
             } else {
                 throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown type '\(type)' for Abstract")
             }
@@ -318,12 +328,16 @@ public enum Documentation: Codable, Equatable, Sendable {
             case .code(let code):
                 try container.encode("codeVoice", forKey: .type)
                 try container.encode(code, forKey: .code)
+            case .reference(let identifier):
+                try container.encode("reference", forKey: .type)
+                try container.encode(identifier, forKey: .identifier)
             }
         }
 
         enum CodingKeys: CodingKey {
             case text
             case code
+            case identifier
             case type
         }
     }

--- a/Tests/BagbutikDocsCollectorTests/DocumentationTests.swift
+++ b/Tests/BagbutikDocsCollectorTests/DocumentationTests.swift
@@ -224,6 +224,51 @@ class DocumentationTests: XCTestCase {
         )
     }
 
+    func testDecodeDocumentationFormatsCodeVoiceInAbstract() throws {
+        let data = """
+        {
+            "identifier": {
+                "url": "doc://com.apple.appstoreconnectapi/documentation/AppStoreConnectAPI/SampleObject"
+            },
+            "hierarchy": {
+                "paths": [[]]
+            },
+            "metadata": {
+                "title": "SampleObject",
+                "symbolKind": "dictionary"
+            },
+            "abstract": [
+                {
+                    "type": "text",
+                    "text": "Use "
+                },
+                {
+                    "type": "codeVoice",
+                    "code": "sampleCode"
+                },
+                {
+                    "type": "text",
+                    "text": " for this object."
+                }
+            ],
+            "primaryContentSections": [
+                {
+                    "kind": "properties",
+                    "items": []
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let documentation = try JSONDecoder().decode(Documentation.self, from: data)
+
+        guard case .object(let objectDocumentation) = documentation else {
+            return XCTFail("Expected object documentation")
+        }
+
+        XCTAssertEqual(objectDocumentation.abstract, "Use sampleCode for this object.")
+    }
+
     func testDecodeEnumDocumentationIgnoresEmptyContentSections() throws {
         let data = """
         {

--- a/Tests/BagbutikDocsCollectorTests/DocumentationTests.swift
+++ b/Tests/BagbutikDocsCollectorTests/DocumentationTests.swift
@@ -169,6 +169,61 @@ class DocumentationTests: XCTestCase {
         XCTAssertEqual(enumDocumentation.cases["MAC_OS"], "[Related Article](https://developer.apple.com/documentation/appstoreconnectapi/related-article)")
     }
 
+    func testDecodeDocumentationFormatsReferencesInAbstract() throws {
+        let data = """
+        {
+            "identifier": {
+                "url": "doc://com.apple.appstoreconnectapi/documentation/AppStoreConnectAPI/GameCenterEnabledVersion"
+            },
+            "hierarchy": {
+                "paths": [[]]
+            },
+            "metadata": {
+                "title": "GameCenterEnabledVersion",
+                "symbolKind": "dictionary"
+            },
+            "abstract": [
+                {
+                    "type": "text",
+                    "text": "An app version with Game Center enabled. Deprecated in API version 3.0; use "
+                },
+                {
+                    "type": "reference",
+                    "identifier": "doc://com.apple.appstoreconnectapi/documentation/AppStoreConnectAPI/GameCenterAppVersion"
+                },
+                {
+                    "type": "text",
+                    "text": " instead."
+                }
+            ],
+            "references": {
+                "doc://com.apple.appstoreconnectapi/documentation/AppStoreConnectAPI/GameCenterAppVersion": {
+                    "title": "GameCenterAppVersion",
+                    "role": "symbol",
+                    "url": "/documentation/appstoreconnectapi/gamecenterappversion"
+                }
+            },
+            "primaryContentSections": [
+                {
+                    "kind": "properties",
+                    "items": []
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let documentation = try JSONDecoder().decode(Documentation.self, from: data)
+
+        guard case .object(let objectDocumentation) = documentation else {
+            return XCTFail("Expected object documentation")
+        }
+
+        XCTAssertEqual(
+            objectDocumentation.abstract,
+            "An app version with Game Center enabled. Deprecated in API version 3.0; use [GameCenterAppVersion](https://developer.apple.com/documentation/appstoreconnectapi/gamecenterappversion) instead."
+        )
+    }
+
     func testDecodeEnumDocumentationIgnoresEmptyContentSections() throws {
         let data = """
         {


### PR DESCRIPTION
## Summary

Fixes documentation decoding for Apple abstracts that now contain inline `reference` items, as seen in `GameCenterEnabledVersion`.

## Root Cause

The docs collector only accepted `text` and `codeVoice` abstract fragments. Apple now emits mixed abstract content with `type: "reference"`, which caused decoding to fail before the docs could be written.

## Changes

- Added abstract reference decoding.
- Reused the existing reference formatting behavior for abstracts and paragraph content.
- Added a regression test for the `GameCenterEnabledVersion` abstract shape.

## Validation

- `swift run bagbutik-cli download-newest-docs --spec-path /tmp/bagbutik-docs-check/spec.json --output-path /tmp/bagbutik-docs-check/Documentation`
- `swift test`
