### PR TITLE
Restore included getters for deprecated relationships

### DIFF
--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationResponse.swift
@@ -44,6 +44,32 @@ public struct AppCustomProductPageLocalizationResponse: Codable, Sendable {
         }.first { $0.id == data.relationships?.appCustomProductPageVersion?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppPreviewSets() -> [AppPreviewSet] {
+        guard let appPreviewSetIds = data.relationships?.appPreviewSets?.data?.map(\.id),
+              let appPreviewSets = included?.compactMap({ relationship -> AppPreviewSet? in
+                  guard case let .appPreviewSet(appPreviewSet) = relationship else { return nil }
+                  return appPreviewSetIds.contains(appPreviewSet.id) ? appPreviewSet : nil
+              })
+        else {
+            return []
+        }
+        return appPreviewSets
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppScreenshotSets() -> [AppScreenshotSet] {
+        guard let appScreenshotSetIds = data.relationships?.appScreenshotSets?.data?.map(\.id),
+              let appScreenshotSets = included?.compactMap({ relationship -> AppScreenshotSet? in
+                  guard case let .appScreenshotSet(appScreenshotSet) = relationship else { return nil }
+                  return appScreenshotSetIds.contains(appScreenshotSet.id) ? appScreenshotSet : nil
+              })
+        else {
+            return []
+        }
+        return appScreenshotSets
+    }
+
     public func getSearchKeywords() -> [AppKeyword] {
         guard let searchKeywordIds = data.relationships?.searchKeywords?.data?.map(\.id),
               let searchKeywords = included?.compactMap({ relationship -> AppKeyword? in

--- a/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppCustomProductPageLocalizationsResponse.swift
@@ -51,6 +51,32 @@ public struct AppCustomProductPageLocalizationsResponse: Codable, Sendable, Page
         }.first { $0.id == appCustomProductPageLocalization.relationships?.appCustomProductPageVersion?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppPreviewSets(for appCustomProductPageLocalization: AppCustomProductPageLocalization) -> [AppPreviewSet] {
+        guard let appPreviewSetIds = appCustomProductPageLocalization.relationships?.appPreviewSets?.data?.map(\.id),
+              let appPreviewSets = included?.compactMap({ relationship -> AppPreviewSet? in
+                  guard case let .appPreviewSet(appPreviewSet) = relationship else { return nil }
+                  return appPreviewSetIds.contains(appPreviewSet.id) ? appPreviewSet : nil
+              })
+        else {
+            return []
+        }
+        return appPreviewSets
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppScreenshotSets(for appCustomProductPageLocalization: AppCustomProductPageLocalization) -> [AppScreenshotSet] {
+        guard let appScreenshotSetIds = appCustomProductPageLocalization.relationships?.appScreenshotSets?.data?.map(\.id),
+              let appScreenshotSets = included?.compactMap({ relationship -> AppScreenshotSet? in
+                  guard case let .appScreenshotSet(appScreenshotSet) = relationship else { return nil }
+                  return appScreenshotSetIds.contains(appScreenshotSet.id) ? appScreenshotSet : nil
+              })
+        else {
+            return []
+        }
+        return appScreenshotSets
+    }
+
     public func getSearchKeywords(for appCustomProductPageLocalization: AppCustomProductPageLocalization) -> [AppKeyword] {
         guard let searchKeywordIds = appCustomProductPageLocalization.relationships?.searchKeywords?.data?.map(\.id),
               let searchKeywords = included?.compactMap({ relationship -> AppKeyword? in

--- a/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationResponse.swift
@@ -39,11 +39,32 @@ public struct AppEncryptionDeclarationResponse: Codable, Sendable {
         try container.encode(links, forKey: "links")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getApp() -> App? {
+        included?.compactMap { relationship -> App? in
+            guard case let .app(app) = relationship else { return nil }
+            return app
+        }.first { $0.id == data.relationships?.app?.data?.id }
+    }
+
     public func getAppEncryptionDeclarationDocument() -> AppEncryptionDeclarationDocument? {
         included?.compactMap { relationship -> AppEncryptionDeclarationDocument? in
             guard case let .appEncryptionDeclarationDocument(appEncryptionDeclarationDocument) = relationship else { return nil }
             return appEncryptionDeclarationDocument
         }.first { $0.id == data.relationships?.appEncryptionDeclarationDocument?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getBuilds() -> [Build] {
+        guard let buildIds = data.relationships?.builds?.data?.map(\.id),
+              let builds = included?.compactMap({ relationship -> Build? in
+                  guard case let .build(build) = relationship else { return nil }
+                  return buildIds.contains(build.id) ? build : nil
+              })
+        else {
+            return []
+        }
+        return builds
     }
 
     public enum Included: Codable, Sendable {

--- a/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEncryptionDeclarationsResponse.swift
@@ -47,11 +47,32 @@ public struct AppEncryptionDeclarationsResponse: Codable, Sendable, PagedRespons
         try container.encodeIfPresent(meta, forKey: "meta")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getApp(for appEncryptionDeclaration: AppEncryptionDeclaration) -> App? {
+        included?.compactMap { relationship -> App? in
+            guard case let .app(app) = relationship else { return nil }
+            return app
+        }.first { $0.id == appEncryptionDeclaration.relationships?.app?.data?.id }
+    }
+
     public func getAppEncryptionDeclarationDocument(for appEncryptionDeclaration: AppEncryptionDeclaration) -> AppEncryptionDeclarationDocument? {
         included?.compactMap { relationship -> AppEncryptionDeclarationDocument? in
             guard case let .appEncryptionDeclarationDocument(appEncryptionDeclarationDocument) = relationship else { return nil }
             return appEncryptionDeclarationDocument
         }.first { $0.id == appEncryptionDeclaration.relationships?.appEncryptionDeclarationDocument?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getBuilds(for appEncryptionDeclaration: AppEncryptionDeclaration) -> [Build] {
+        guard let buildIds = appEncryptionDeclaration.relationships?.builds?.data?.map(\.id),
+              let builds = included?.compactMap({ relationship -> Build? in
+                  guard case let .build(build) = relationship else { return nil }
+                  return buildIds.contains(build.id) ? build : nil
+              })
+        else {
+            return []
+        }
+        return builds
     }
 
     public enum Included: Codable, Sendable {

--- a/Sources/Bagbutik-AppStore/Models/AppEventLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEventLocalizationResponse.swift
@@ -44,6 +44,32 @@ public struct AppEventLocalizationResponse: Codable, Sendable {
         }.first { $0.id == data.relationships?.appEvent?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppEventScreenshots() -> [AppEventScreenshot] {
+        guard let appEventScreenshotIds = data.relationships?.appEventScreenshots?.data?.map(\.id),
+              let appEventScreenshots = included?.compactMap({ relationship -> AppEventScreenshot? in
+                  guard case let .appEventScreenshot(appEventScreenshot) = relationship else { return nil }
+                  return appEventScreenshotIds.contains(appEventScreenshot.id) ? appEventScreenshot : nil
+              })
+        else {
+            return []
+        }
+        return appEventScreenshots
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppEventVideoClips() -> [AppEventVideoClip] {
+        guard let appEventVideoClipIds = data.relationships?.appEventVideoClips?.data?.map(\.id),
+              let appEventVideoClips = included?.compactMap({ relationship -> AppEventVideoClip? in
+                  guard case let .appEventVideoClip(appEventVideoClip) = relationship else { return nil }
+                  return appEventVideoClipIds.contains(appEventVideoClip.id) ? appEventVideoClip : nil
+              })
+        else {
+            return []
+        }
+        return appEventVideoClips
+    }
+
     public enum Included: Codable, Sendable {
         case appEvent(AppEvent)
         case appEventScreenshot(AppEventScreenshot)

--- a/Sources/Bagbutik-AppStore/Models/AppEventLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppEventLocalizationsResponse.swift
@@ -51,6 +51,32 @@ public struct AppEventLocalizationsResponse: Codable, Sendable, PagedResponse {
         }.first { $0.id == appEventLocalization.relationships?.appEvent?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppEventScreenshots(for appEventLocalization: AppEventLocalization) -> [AppEventScreenshot] {
+        guard let appEventScreenshotIds = appEventLocalization.relationships?.appEventScreenshots?.data?.map(\.id),
+              let appEventScreenshots = included?.compactMap({ relationship -> AppEventScreenshot? in
+                  guard case let .appEventScreenshot(appEventScreenshot) = relationship else { return nil }
+                  return appEventScreenshotIds.contains(appEventScreenshot.id) ? appEventScreenshot : nil
+              })
+        else {
+            return []
+        }
+        return appEventScreenshots
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppEventVideoClips(for appEventLocalization: AppEventLocalization) -> [AppEventVideoClip] {
+        guard let appEventVideoClipIds = appEventLocalization.relationships?.appEventVideoClips?.data?.map(\.id),
+              let appEventVideoClips = included?.compactMap({ relationship -> AppEventVideoClip? in
+                  guard case let .appEventVideoClip(appEventVideoClip) = relationship else { return nil }
+                  return appEventVideoClipIds.contains(appEventVideoClip.id) ? appEventVideoClip : nil
+              })
+        else {
+            return []
+        }
+        return appEventVideoClips
+    }
+
     public enum Included: Codable, Sendable {
         case appEvent(AppEvent)
         case appEventScreenshot(AppEventScreenshot)

--- a/Sources/Bagbutik-AppStore/Models/AppResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppResponse.swift
@@ -225,6 +225,19 @@ public struct AppResponse: Codable, Sendable {
         return gameCenterEnabledVersions
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getInAppPurchases() -> [InAppPurchase] {
+        guard let inAppPurchaseIds = data.relationships?.inAppPurchases?.data?.map(\.id),
+              let inAppPurchases = included?.compactMap({ relationship -> InAppPurchase? in
+                  guard case let .inAppPurchase(inAppPurchase) = relationship else { return nil }
+                  return inAppPurchaseIds.contains(inAppPurchase.id) ? inAppPurchase : nil
+              })
+        else {
+            return []
+        }
+        return inAppPurchases
+    }
+
     public func getInAppPurchasesV2() -> [InAppPurchase] {
         guard let inAppPurchasesV2Ids = data.relationships?.inAppPurchasesV2?.data?.map(\.id),
               let inAppPurchasesV2 = included?.compactMap({ relationship -> InAppPurchase? in

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationResponse.swift
@@ -37,6 +37,32 @@ public struct AppStoreVersionExperimentTreatmentLocalizationResponse: Codable, S
         try container.encode(links, forKey: "links")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppPreviewSets() -> [AppPreviewSet] {
+        guard let appPreviewSetIds = data.relationships?.appPreviewSets?.data?.map(\.id),
+              let appPreviewSets = included?.compactMap({ relationship -> AppPreviewSet? in
+                  guard case let .appPreviewSet(appPreviewSet) = relationship else { return nil }
+                  return appPreviewSetIds.contains(appPreviewSet.id) ? appPreviewSet : nil
+              })
+        else {
+            return []
+        }
+        return appPreviewSets
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppScreenshotSets() -> [AppScreenshotSet] {
+        guard let appScreenshotSetIds = data.relationships?.appScreenshotSets?.data?.map(\.id),
+              let appScreenshotSets = included?.compactMap({ relationship -> AppScreenshotSet? in
+                  guard case let .appScreenshotSet(appScreenshotSet) = relationship else { return nil }
+                  return appScreenshotSetIds.contains(appScreenshotSet.id) ? appScreenshotSet : nil
+              })
+        else {
+            return []
+        }
+        return appScreenshotSets
+    }
+
     public func getAppStoreVersionExperimentTreatment() -> AppStoreVersionExperimentTreatment? {
         included?.compactMap { relationship -> AppStoreVersionExperimentTreatment? in
             guard case let .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment) = relationship else { return nil }

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionExperimentTreatmentLocalizationsResponse.swift
@@ -44,6 +44,32 @@ public struct AppStoreVersionExperimentTreatmentLocalizationsResponse: Codable, 
         try container.encodeIfPresent(meta, forKey: "meta")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppPreviewSets(for appStoreVersionExperimentTreatmentLocalization: AppStoreVersionExperimentTreatmentLocalization) -> [AppPreviewSet] {
+        guard let appPreviewSetIds = appStoreVersionExperimentTreatmentLocalization.relationships?.appPreviewSets?.data?.map(\.id),
+              let appPreviewSets = included?.compactMap({ relationship -> AppPreviewSet? in
+                  guard case let .appPreviewSet(appPreviewSet) = relationship else { return nil }
+                  return appPreviewSetIds.contains(appPreviewSet.id) ? appPreviewSet : nil
+              })
+        else {
+            return []
+        }
+        return appPreviewSets
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppScreenshotSets(for appStoreVersionExperimentTreatmentLocalization: AppStoreVersionExperimentTreatmentLocalization) -> [AppScreenshotSet] {
+        guard let appScreenshotSetIds = appStoreVersionExperimentTreatmentLocalization.relationships?.appScreenshotSets?.data?.map(\.id),
+              let appScreenshotSets = included?.compactMap({ relationship -> AppScreenshotSet? in
+                  guard case let .appScreenshotSet(appScreenshotSet) = relationship else { return nil }
+                  return appScreenshotSetIds.contains(appScreenshotSet.id) ? appScreenshotSet : nil
+              })
+        else {
+            return []
+        }
+        return appScreenshotSets
+    }
+
     public func getAppStoreVersionExperimentTreatment(for appStoreVersionExperimentTreatmentLocalization: AppStoreVersionExperimentTreatmentLocalization) -> AppStoreVersionExperimentTreatment? {
         included?.compactMap { relationship -> AppStoreVersionExperimentTreatment? in
             guard case let .appStoreVersionExperimentTreatment(appStoreVersionExperimentTreatment) = relationship else { return nil }

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationResponse.swift
@@ -37,6 +37,32 @@ public struct AppStoreVersionLocalizationResponse: Codable, Sendable {
         try container.encode(links, forKey: "links")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppPreviewSets() -> [AppPreviewSet] {
+        guard let appPreviewSetIds = data.relationships?.appPreviewSets?.data?.map(\.id),
+              let appPreviewSets = included?.compactMap({ relationship -> AppPreviewSet? in
+                  guard case let .appPreviewSet(appPreviewSet) = relationship else { return nil }
+                  return appPreviewSetIds.contains(appPreviewSet.id) ? appPreviewSet : nil
+              })
+        else {
+            return []
+        }
+        return appPreviewSets
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppScreenshotSets() -> [AppScreenshotSet] {
+        guard let appScreenshotSetIds = data.relationships?.appScreenshotSets?.data?.map(\.id),
+              let appScreenshotSets = included?.compactMap({ relationship -> AppScreenshotSet? in
+                  guard case let .appScreenshotSet(appScreenshotSet) = relationship else { return nil }
+                  return appScreenshotSetIds.contains(appScreenshotSet.id) ? appScreenshotSet : nil
+              })
+        else {
+            return []
+        }
+        return appScreenshotSets
+    }
+
     public func getAppStoreVersion() -> AppStoreVersion? {
         included?.compactMap { relationship -> AppStoreVersion? in
             guard case let .appStoreVersion(appStoreVersion) = relationship else { return nil }

--- a/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppStoreVersionLocalizationsResponse.swift
@@ -44,6 +44,32 @@ public struct AppStoreVersionLocalizationsResponse: Codable, Sendable, PagedResp
         try container.encodeIfPresent(meta, forKey: "meta")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppPreviewSets(for appStoreVersionLocalization: AppStoreVersionLocalization) -> [AppPreviewSet] {
+        guard let appPreviewSetIds = appStoreVersionLocalization.relationships?.appPreviewSets?.data?.map(\.id),
+              let appPreviewSets = included?.compactMap({ relationship -> AppPreviewSet? in
+                  guard case let .appPreviewSet(appPreviewSet) = relationship else { return nil }
+                  return appPreviewSetIds.contains(appPreviewSet.id) ? appPreviewSet : nil
+              })
+        else {
+            return []
+        }
+        return appPreviewSets
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAppScreenshotSets(for appStoreVersionLocalization: AppStoreVersionLocalization) -> [AppScreenshotSet] {
+        guard let appScreenshotSetIds = appStoreVersionLocalization.relationships?.appScreenshotSets?.data?.map(\.id),
+              let appScreenshotSets = included?.compactMap({ relationship -> AppScreenshotSet? in
+                  guard case let .appScreenshotSet(appScreenshotSet) = relationship else { return nil }
+                  return appScreenshotSetIds.contains(appScreenshotSet.id) ? appScreenshotSet : nil
+              })
+        else {
+            return []
+        }
+        return appScreenshotSets
+    }
+
     public func getAppStoreVersion(for appStoreVersionLocalization: AppStoreVersionLocalization) -> AppStoreVersion? {
         included?.compactMap { relationship -> AppStoreVersion? in
             guard case let .appStoreVersion(appStoreVersion) = relationship else { return nil }

--- a/Sources/Bagbutik-AppStore/Models/AppsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/AppsResponse.swift
@@ -233,6 +233,19 @@ public struct AppsResponse: Codable, Sendable, PagedResponse {
         return gameCenterEnabledVersions
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getInAppPurchases(for app: App) -> [InAppPurchase] {
+        guard let inAppPurchaseIds = app.relationships?.inAppPurchases?.data?.map(\.id),
+              let inAppPurchases = included?.compactMap({ relationship -> InAppPurchase? in
+                  guard case let .inAppPurchase(inAppPurchase) = relationship else { return nil }
+                  return inAppPurchaseIds.contains(inAppPurchase.id) ? inAppPurchase : nil
+              })
+        else {
+            return []
+        }
+        return inAppPurchases
+    }
+
     public func getInAppPurchasesV2(for app: App) -> [InAppPurchase] {
         guard let inAppPurchasesV2Ids = app.relationships?.inAppPurchasesV2?.data?.map(\.id),
               let inAppPurchasesV2 = included?.compactMap({ relationship -> InAppPurchase? in

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionResponse.swift
@@ -130,6 +130,14 @@ public struct SubscriptionResponse: Codable, Sendable {
         return promotionalOffers
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getSubscriptionAvailability() -> SubscriptionAvailability? {
+        included?.compactMap { relationship -> SubscriptionAvailability? in
+            guard case let .subscriptionAvailability(subscriptionAvailability) = relationship else { return nil }
+            return subscriptionAvailability
+        }.first { $0.id == data.relationships?.subscriptionAvailability?.data?.id }
+    }
+
     public func getSubscriptionLocalizations() -> [SubscriptionLocalization] {
         guard let subscriptionLocalizationIds = data.relationships?.subscriptionLocalizations?.data?.map(\.id),
               let subscriptionLocalizations = included?.compactMap({ relationship -> SubscriptionLocalization? in

--- a/Sources/Bagbutik-AppStore/Models/SubscriptionsResponse.swift
+++ b/Sources/Bagbutik-AppStore/Models/SubscriptionsResponse.swift
@@ -137,6 +137,14 @@ public struct SubscriptionsResponse: Codable, Sendable, PagedResponse {
         return promotionalOffers
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getSubscriptionAvailability(for subscription: Subscription) -> SubscriptionAvailability? {
+        included?.compactMap { relationship -> SubscriptionAvailability? in
+            guard case let .subscriptionAvailability(subscriptionAvailability) = relationship else { return nil }
+            return subscriptionAvailability
+        }.first { $0.id == subscription.relationships?.subscriptionAvailability?.data?.id }
+    }
+
     public func getSubscriptionLocalizations(for subscription: Subscription) -> [SubscriptionLocalization] {
         guard let subscriptionLocalizationIds = subscription.relationships?.subscriptionLocalizations?.data?.map(\.id),
               let subscriptionLocalizations = included?.compactMap({ relationship -> SubscriptionLocalization? in

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementResponse.swift
@@ -58,6 +58,14 @@ public struct GameCenterAchievementResponse: Codable, Sendable {
         }.first { $0.id == data.relationships?.gameCenterGroup?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGroupAchievement() -> GameCenterAchievement? {
+        included?.compactMap { relationship -> GameCenterAchievement? in
+            guard case let .gameCenterAchievement(groupAchievement) = relationship else { return nil }
+            return groupAchievement
+        }.first { $0.id == data.relationships?.groupAchievement?.data?.id }
+    }
+
     public func getLocalizations() -> [GameCenterAchievementLocalization] {
         guard let localizationIds = data.relationships?.localizations?.data?.map(\.id),
               let localizations = included?.compactMap({ relationship -> GameCenterAchievementLocalization? in

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterAchievementsResponse.swift
@@ -65,6 +65,14 @@ public struct GameCenterAchievementsResponse: Codable, Sendable, PagedResponse {
         }.first { $0.id == gameCenterAchievement.relationships?.gameCenterGroup?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGroupAchievement(for gameCenterAchievement: GameCenterAchievement) -> GameCenterAchievement? {
+        included?.compactMap { relationship -> GameCenterAchievement? in
+            guard case let .gameCenterAchievement(groupAchievement) = relationship else { return nil }
+            return groupAchievement
+        }.first { $0.id == gameCenterAchievement.relationships?.groupAchievement?.data?.id }
+    }
+
     public func getLocalizations(for gameCenterAchievement: GameCenterAchievement) -> [GameCenterAchievementLocalization] {
         guard let localizationIds = gameCenterAchievement.relationships?.localizations?.data?.map(\.id),
               let localizations = included?.compactMap({ relationship -> GameCenterAchievementLocalization? in

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivitiesResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivitiesResponse.swift
@@ -44,6 +44,19 @@ public struct GameCenterActivitiesResponse: Codable, Sendable, PagedResponse {
         try container.encodeIfPresent(meta, forKey: "meta")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAchievements(for gameCenterActivity: GameCenterActivity) -> [GameCenterAchievement] {
+        guard let achievementIds = gameCenterActivity.relationships?.achievements?.data?.map(\.id),
+              let achievements = included?.compactMap({ relationship -> GameCenterAchievement? in
+                  guard case let .gameCenterAchievement(achievement) = relationship else { return nil }
+                  return achievementIds.contains(achievement.id) ? achievement : nil
+              })
+        else {
+            return []
+        }
+        return achievements
+    }
+
     public func getAchievementsV2(for gameCenterActivity: GameCenterActivity) -> [GameCenterAchievement] {
         guard let achievementsV2Ids = gameCenterActivity.relationships?.achievementsV2?.data?.map(\.id),
               let achievementsV2 = included?.compactMap({ relationship -> GameCenterAchievement? in
@@ -68,6 +81,19 @@ public struct GameCenterActivitiesResponse: Codable, Sendable, PagedResponse {
             guard case let .gameCenterGroup(gameCenterGroup) = relationship else { return nil }
             return gameCenterGroup
         }.first { $0.id == gameCenterActivity.relationships?.gameCenterGroup?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboards(for gameCenterActivity: GameCenterActivity) -> [GameCenterLeaderboard] {
+        guard let leaderboardIds = gameCenterActivity.relationships?.leaderboards?.data?.map(\.id),
+              let leaderboards = included?.compactMap({ relationship -> GameCenterLeaderboard? in
+                  guard case let .gameCenterLeaderboard(leaderboard) = relationship else { return nil }
+                  return leaderboardIds.contains(leaderboard.id) ? leaderboard : nil
+              })
+        else {
+            return []
+        }
+        return leaderboards
     }
 
     public func getLeaderboardsV2(for gameCenterActivity: GameCenterActivity) -> [GameCenterLeaderboard] {

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterActivityResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterActivityResponse.swift
@@ -37,6 +37,19 @@ public struct GameCenterActivityResponse: Codable, Sendable {
         try container.encode(links, forKey: "links")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAchievements() -> [GameCenterAchievement] {
+        guard let achievementIds = data.relationships?.achievements?.data?.map(\.id),
+              let achievements = included?.compactMap({ relationship -> GameCenterAchievement? in
+                  guard case let .gameCenterAchievement(achievement) = relationship else { return nil }
+                  return achievementIds.contains(achievement.id) ? achievement : nil
+              })
+        else {
+            return []
+        }
+        return achievements
+    }
+
     public func getAchievementsV2() -> [GameCenterAchievement] {
         guard let achievementsV2Ids = data.relationships?.achievementsV2?.data?.map(\.id),
               let achievementsV2 = included?.compactMap({ relationship -> GameCenterAchievement? in
@@ -61,6 +74,19 @@ public struct GameCenterActivityResponse: Codable, Sendable {
             guard case let .gameCenterGroup(gameCenterGroup) = relationship else { return nil }
             return gameCenterGroup
         }.first { $0.id == data.relationships?.gameCenterGroup?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboards() -> [GameCenterLeaderboard] {
+        guard let leaderboardIds = data.relationships?.leaderboards?.data?.map(\.id),
+              let leaderboards = included?.compactMap({ relationship -> GameCenterLeaderboard? in
+                  guard case let .gameCenterLeaderboard(leaderboard) = relationship else { return nil }
+                  return leaderboardIds.contains(leaderboard.id) ? leaderboard : nil
+              })
+        else {
+            return []
+        }
+        return leaderboards
     }
 
     public func getLeaderboardsV2() -> [GameCenterLeaderboard] {

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengeResponse.swift
@@ -51,6 +51,14 @@ public struct GameCenterChallengeResponse: Codable, Sendable {
         }.first { $0.id == data.relationships?.gameCenterGroup?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboard() -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(leaderboard) = relationship else { return nil }
+            return leaderboard
+        }.first { $0.id == data.relationships?.leaderboard?.data?.id }
+    }
+
     public func getLeaderboardV2() -> GameCenterLeaderboard? {
         included?.compactMap { relationship -> GameCenterLeaderboard? in
             guard case let .gameCenterLeaderboard(leaderboardV2) = relationship else { return nil }

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterChallengesResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterChallengesResponse.swift
@@ -58,6 +58,14 @@ public struct GameCenterChallengesResponse: Codable, Sendable, PagedResponse {
         }.first { $0.id == gameCenterChallenge.relationships?.gameCenterGroup?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboard(for gameCenterChallenge: GameCenterChallenge) -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(leaderboard) = relationship else { return nil }
+            return leaderboard
+        }.first { $0.id == gameCenterChallenge.relationships?.leaderboard?.data?.id }
+    }
+
     public func getLeaderboardV2(for gameCenterChallenge: GameCenterChallenge) -> GameCenterLeaderboard? {
         included?.compactMap { relationship -> GameCenterLeaderboard? in
             guard case let .gameCenterLeaderboard(leaderboardV2) = relationship else { return nil }

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterDetailResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterDetailResponse.swift
@@ -37,11 +37,50 @@ public struct GameCenterDetailResponse: Codable, Sendable {
         try container.encode(links, forKey: "links")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAchievementReleases() -> [GameCenterAchievementRelease] {
+        guard let achievementReleaseIds = data.relationships?.achievementReleases?.data?.map(\.id),
+              let achievementReleases = included?.compactMap({ relationship -> GameCenterAchievementRelease? in
+                  guard case let .gameCenterAchievementRelease(achievementRelease) = relationship else { return nil }
+                  return achievementReleaseIds.contains(achievementRelease.id) ? achievementRelease : nil
+              })
+        else {
+            return []
+        }
+        return achievementReleases
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getActivityReleases() -> [GameCenterActivityVersionRelease] {
+        guard let activityReleaseIds = data.relationships?.activityReleases?.data?.map(\.id),
+              let activityReleases = included?.compactMap({ relationship -> GameCenterActivityVersionRelease? in
+                  guard case let .gameCenterActivityVersionRelease(activityRelease) = relationship else { return nil }
+                  return activityReleaseIds.contains(activityRelease.id) ? activityRelease : nil
+              })
+        else {
+            return []
+        }
+        return activityReleases
+    }
+
     public func getApp() -> App? {
         included?.compactMap { relationship -> App? in
             guard case let .app(app) = relationship else { return nil }
             return app
         }.first { $0.id == data.relationships?.app?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getChallengeReleases() -> [GameCenterChallengeVersionRelease] {
+        guard let challengeReleaseIds = data.relationships?.challengeReleases?.data?.map(\.id),
+              let challengeReleases = included?.compactMap({ relationship -> GameCenterChallengeVersionRelease? in
+                  guard case let .gameCenterChallengeVersionRelease(challengeRelease) = relationship else { return nil }
+                  return challengeReleaseIds.contains(challengeRelease.id) ? challengeRelease : nil
+              })
+        else {
+            return []
+        }
+        return challengeReleases
     }
 
     public func getChallengesMinimumPlatformVersions() -> [AppStoreVersion] {
@@ -56,6 +95,14 @@ public struct GameCenterDetailResponse: Codable, Sendable {
         return challengesMinimumPlatformVersions
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getDefaultGroupLeaderboard() -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(defaultGroupLeaderboard) = relationship else { return nil }
+            return defaultGroupLeaderboard
+        }.first { $0.id == data.relationships?.defaultGroupLeaderboard?.data?.id }
+    }
+
     public func getDefaultGroupLeaderboardV2() -> GameCenterLeaderboard? {
         included?.compactMap { relationship -> GameCenterLeaderboard? in
             guard case let .gameCenterLeaderboard(defaultGroupLeaderboardV2) = relationship else { return nil }
@@ -63,11 +110,32 @@ public struct GameCenterDetailResponse: Codable, Sendable {
         }.first { $0.id == data.relationships?.defaultGroupLeaderboardV2?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getDefaultLeaderboard() -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(defaultLeaderboard) = relationship else { return nil }
+            return defaultLeaderboard
+        }.first { $0.id == data.relationships?.defaultLeaderboard?.data?.id }
+    }
+
     public func getDefaultLeaderboardV2() -> GameCenterLeaderboard? {
         included?.compactMap { relationship -> GameCenterLeaderboard? in
             guard case let .gameCenterLeaderboard(defaultLeaderboardV2) = relationship else { return nil }
             return defaultLeaderboardV2
         }.first { $0.id == data.relationships?.defaultLeaderboardV2?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterAchievements() -> [GameCenterAchievement] {
+        guard let gameCenterAchievementIds = data.relationships?.gameCenterAchievements?.data?.map(\.id),
+              let gameCenterAchievements = included?.compactMap({ relationship -> GameCenterAchievement? in
+                  guard case let .gameCenterAchievement(gameCenterAchievement) = relationship else { return nil }
+                  return gameCenterAchievementIds.contains(gameCenterAchievement.id) ? gameCenterAchievement : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterAchievements
     }
 
     public func getGameCenterAchievementsV2() -> [GameCenterAchievement] {
@@ -125,6 +193,19 @@ public struct GameCenterDetailResponse: Codable, Sendable {
         }.first { $0.id == data.relationships?.gameCenterGroup?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboardSets() -> [GameCenterLeaderboardSet] {
+        guard let gameCenterLeaderboardSetIds = data.relationships?.gameCenterLeaderboardSets?.data?.map(\.id),
+              let gameCenterLeaderboardSets = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
+                  guard case let .gameCenterLeaderboardSet(gameCenterLeaderboardSet) = relationship else { return nil }
+                  return gameCenterLeaderboardSetIds.contains(gameCenterLeaderboardSet.id) ? gameCenterLeaderboardSet : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboardSets
+    }
+
     public func getGameCenterLeaderboardSetsV2() -> [GameCenterLeaderboardSet] {
         guard let gameCenterLeaderboardSetsV2Ids = data.relationships?.gameCenterLeaderboardSetsV2?.data?.map(\.id),
               let gameCenterLeaderboardSetsV2 = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
@@ -137,6 +218,19 @@ public struct GameCenterDetailResponse: Codable, Sendable {
         return gameCenterLeaderboardSetsV2
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboards() -> [GameCenterLeaderboard] {
+        guard let gameCenterLeaderboardIds = data.relationships?.gameCenterLeaderboards?.data?.map(\.id),
+              let gameCenterLeaderboards = included?.compactMap({ relationship -> GameCenterLeaderboard? in
+                  guard case let .gameCenterLeaderboard(gameCenterLeaderboard) = relationship else { return nil }
+                  return gameCenterLeaderboardIds.contains(gameCenterLeaderboard.id) ? gameCenterLeaderboard : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboards
+    }
+
     public func getGameCenterLeaderboardsV2() -> [GameCenterLeaderboard] {
         guard let gameCenterLeaderboardsV2Ids = data.relationships?.gameCenterLeaderboardsV2?.data?.map(\.id),
               let gameCenterLeaderboardsV2 = included?.compactMap({ relationship -> GameCenterLeaderboard? in
@@ -147,6 +241,32 @@ public struct GameCenterDetailResponse: Codable, Sendable {
             return []
         }
         return gameCenterLeaderboardsV2
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboardReleases() -> [GameCenterLeaderboardRelease] {
+        guard let leaderboardReleaseIds = data.relationships?.leaderboardReleases?.data?.map(\.id),
+              let leaderboardReleases = included?.compactMap({ relationship -> GameCenterLeaderboardRelease? in
+                  guard case let .gameCenterLeaderboardRelease(leaderboardRelease) = relationship else { return nil }
+                  return leaderboardReleaseIds.contains(leaderboardRelease.id) ? leaderboardRelease : nil
+              })
+        else {
+            return []
+        }
+        return leaderboardReleases
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboardSetReleases() -> [GameCenterLeaderboardSetRelease] {
+        guard let leaderboardSetReleaseIds = data.relationships?.leaderboardSetReleases?.data?.map(\.id),
+              let leaderboardSetReleases = included?.compactMap({ relationship -> GameCenterLeaderboardSetRelease? in
+                  guard case let .gameCenterLeaderboardSetRelease(leaderboardSetRelease) = relationship else { return nil }
+                  return leaderboardSetReleaseIds.contains(leaderboardSetRelease.id) ? leaderboardSetRelease : nil
+              })
+        else {
+            return []
+        }
+        return leaderboardSetReleases
     }
 
     public enum Included: Codable, Sendable {

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterDetailsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterDetailsResponse.swift
@@ -44,11 +44,50 @@ public struct GameCenterDetailsResponse: Codable, Sendable, PagedResponse {
         try container.encodeIfPresent(meta, forKey: "meta")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getAchievementReleases(for gameCenterDetail: GameCenterDetail) -> [GameCenterAchievementRelease] {
+        guard let achievementReleaseIds = gameCenterDetail.relationships?.achievementReleases?.data?.map(\.id),
+              let achievementReleases = included?.compactMap({ relationship -> GameCenterAchievementRelease? in
+                  guard case let .gameCenterAchievementRelease(achievementRelease) = relationship else { return nil }
+                  return achievementReleaseIds.contains(achievementRelease.id) ? achievementRelease : nil
+              })
+        else {
+            return []
+        }
+        return achievementReleases
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getActivityReleases(for gameCenterDetail: GameCenterDetail) -> [GameCenterActivityVersionRelease] {
+        guard let activityReleaseIds = gameCenterDetail.relationships?.activityReleases?.data?.map(\.id),
+              let activityReleases = included?.compactMap({ relationship -> GameCenterActivityVersionRelease? in
+                  guard case let .gameCenterActivityVersionRelease(activityRelease) = relationship else { return nil }
+                  return activityReleaseIds.contains(activityRelease.id) ? activityRelease : nil
+              })
+        else {
+            return []
+        }
+        return activityReleases
+    }
+
     public func getApp(for gameCenterDetail: GameCenterDetail) -> App? {
         included?.compactMap { relationship -> App? in
             guard case let .app(app) = relationship else { return nil }
             return app
         }.first { $0.id == gameCenterDetail.relationships?.app?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getChallengeReleases(for gameCenterDetail: GameCenterDetail) -> [GameCenterChallengeVersionRelease] {
+        guard let challengeReleaseIds = gameCenterDetail.relationships?.challengeReleases?.data?.map(\.id),
+              let challengeReleases = included?.compactMap({ relationship -> GameCenterChallengeVersionRelease? in
+                  guard case let .gameCenterChallengeVersionRelease(challengeRelease) = relationship else { return nil }
+                  return challengeReleaseIds.contains(challengeRelease.id) ? challengeRelease : nil
+              })
+        else {
+            return []
+        }
+        return challengeReleases
     }
 
     public func getChallengesMinimumPlatformVersions(for gameCenterDetail: GameCenterDetail) -> [AppStoreVersion] {
@@ -63,6 +102,14 @@ public struct GameCenterDetailsResponse: Codable, Sendable, PagedResponse {
         return challengesMinimumPlatformVersions
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getDefaultGroupLeaderboard(for gameCenterDetail: GameCenterDetail) -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(defaultGroupLeaderboard) = relationship else { return nil }
+            return defaultGroupLeaderboard
+        }.first { $0.id == gameCenterDetail.relationships?.defaultGroupLeaderboard?.data?.id }
+    }
+
     public func getDefaultGroupLeaderboardV2(for gameCenterDetail: GameCenterDetail) -> GameCenterLeaderboard? {
         included?.compactMap { relationship -> GameCenterLeaderboard? in
             guard case let .gameCenterLeaderboard(defaultGroupLeaderboardV2) = relationship else { return nil }
@@ -70,11 +117,32 @@ public struct GameCenterDetailsResponse: Codable, Sendable, PagedResponse {
         }.first { $0.id == gameCenterDetail.relationships?.defaultGroupLeaderboardV2?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getDefaultLeaderboard(for gameCenterDetail: GameCenterDetail) -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(defaultLeaderboard) = relationship else { return nil }
+            return defaultLeaderboard
+        }.first { $0.id == gameCenterDetail.relationships?.defaultLeaderboard?.data?.id }
+    }
+
     public func getDefaultLeaderboardV2(for gameCenterDetail: GameCenterDetail) -> GameCenterLeaderboard? {
         included?.compactMap { relationship -> GameCenterLeaderboard? in
             guard case let .gameCenterLeaderboard(defaultLeaderboardV2) = relationship else { return nil }
             return defaultLeaderboardV2
         }.first { $0.id == gameCenterDetail.relationships?.defaultLeaderboardV2?.data?.id }
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterAchievements(for gameCenterDetail: GameCenterDetail) -> [GameCenterAchievement] {
+        guard let gameCenterAchievementIds = gameCenterDetail.relationships?.gameCenterAchievements?.data?.map(\.id),
+              let gameCenterAchievements = included?.compactMap({ relationship -> GameCenterAchievement? in
+                  guard case let .gameCenterAchievement(gameCenterAchievement) = relationship else { return nil }
+                  return gameCenterAchievementIds.contains(gameCenterAchievement.id) ? gameCenterAchievement : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterAchievements
     }
 
     public func getGameCenterAchievementsV2(for gameCenterDetail: GameCenterDetail) -> [GameCenterAchievement] {
@@ -132,6 +200,19 @@ public struct GameCenterDetailsResponse: Codable, Sendable, PagedResponse {
         }.first { $0.id == gameCenterDetail.relationships?.gameCenterGroup?.data?.id }
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboardSets(for gameCenterDetail: GameCenterDetail) -> [GameCenterLeaderboardSet] {
+        guard let gameCenterLeaderboardSetIds = gameCenterDetail.relationships?.gameCenterLeaderboardSets?.data?.map(\.id),
+              let gameCenterLeaderboardSets = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
+                  guard case let .gameCenterLeaderboardSet(gameCenterLeaderboardSet) = relationship else { return nil }
+                  return gameCenterLeaderboardSetIds.contains(gameCenterLeaderboardSet.id) ? gameCenterLeaderboardSet : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboardSets
+    }
+
     public func getGameCenterLeaderboardSetsV2(for gameCenterDetail: GameCenterDetail) -> [GameCenterLeaderboardSet] {
         guard let gameCenterLeaderboardSetsV2Ids = gameCenterDetail.relationships?.gameCenterLeaderboardSetsV2?.data?.map(\.id),
               let gameCenterLeaderboardSetsV2 = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
@@ -144,6 +225,19 @@ public struct GameCenterDetailsResponse: Codable, Sendable, PagedResponse {
         return gameCenterLeaderboardSetsV2
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboards(for gameCenterDetail: GameCenterDetail) -> [GameCenterLeaderboard] {
+        guard let gameCenterLeaderboardIds = gameCenterDetail.relationships?.gameCenterLeaderboards?.data?.map(\.id),
+              let gameCenterLeaderboards = included?.compactMap({ relationship -> GameCenterLeaderboard? in
+                  guard case let .gameCenterLeaderboard(gameCenterLeaderboard) = relationship else { return nil }
+                  return gameCenterLeaderboardIds.contains(gameCenterLeaderboard.id) ? gameCenterLeaderboard : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboards
+    }
+
     public func getGameCenterLeaderboardsV2(for gameCenterDetail: GameCenterDetail) -> [GameCenterLeaderboard] {
         guard let gameCenterLeaderboardsV2Ids = gameCenterDetail.relationships?.gameCenterLeaderboardsV2?.data?.map(\.id),
               let gameCenterLeaderboardsV2 = included?.compactMap({ relationship -> GameCenterLeaderboard? in
@@ -154,6 +248,32 @@ public struct GameCenterDetailsResponse: Codable, Sendable, PagedResponse {
             return []
         }
         return gameCenterLeaderboardsV2
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboardReleases(for gameCenterDetail: GameCenterDetail) -> [GameCenterLeaderboardRelease] {
+        guard let leaderboardReleaseIds = gameCenterDetail.relationships?.leaderboardReleases?.data?.map(\.id),
+              let leaderboardReleases = included?.compactMap({ relationship -> GameCenterLeaderboardRelease? in
+                  guard case let .gameCenterLeaderboardRelease(leaderboardRelease) = relationship else { return nil }
+                  return leaderboardReleaseIds.contains(leaderboardRelease.id) ? leaderboardRelease : nil
+              })
+        else {
+            return []
+        }
+        return leaderboardReleases
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getLeaderboardSetReleases(for gameCenterDetail: GameCenterDetail) -> [GameCenterLeaderboardSetRelease] {
+        guard let leaderboardSetReleaseIds = gameCenterDetail.relationships?.leaderboardSetReleases?.data?.map(\.id),
+              let leaderboardSetReleases = included?.compactMap({ relationship -> GameCenterLeaderboardSetRelease? in
+                  guard case let .gameCenterLeaderboardSetRelease(leaderboardSetRelease) = relationship else { return nil }
+                  return leaderboardSetReleaseIds.contains(leaderboardSetRelease.id) ? leaderboardSetRelease : nil
+              })
+        else {
+            return []
+        }
+        return leaderboardSetReleases
     }
 
     public enum Included: Codable, Sendable {

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterGroupResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterGroupResponse.swift
@@ -37,6 +37,19 @@ public struct GameCenterGroupResponse: Codable, Sendable {
         try container.encode(links, forKey: "links")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterAchievements() -> [GameCenterAchievement] {
+        guard let gameCenterAchievementIds = data.relationships?.gameCenterAchievements?.data?.map(\.id),
+              let gameCenterAchievements = included?.compactMap({ relationship -> GameCenterAchievement? in
+                  guard case let .gameCenterAchievement(gameCenterAchievement) = relationship else { return nil }
+                  return gameCenterAchievementIds.contains(gameCenterAchievement.id) ? gameCenterAchievement : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterAchievements
+    }
+
     public func getGameCenterAchievementsV2() -> [GameCenterAchievement] {
         guard let gameCenterAchievementsV2Ids = data.relationships?.gameCenterAchievementsV2?.data?.map(\.id),
               let gameCenterAchievementsV2 = included?.compactMap({ relationship -> GameCenterAchievement? in
@@ -85,6 +98,19 @@ public struct GameCenterGroupResponse: Codable, Sendable {
         return gameCenterDetails
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboardSets() -> [GameCenterLeaderboardSet] {
+        guard let gameCenterLeaderboardSetIds = data.relationships?.gameCenterLeaderboardSets?.data?.map(\.id),
+              let gameCenterLeaderboardSets = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
+                  guard case let .gameCenterLeaderboardSet(gameCenterLeaderboardSet) = relationship else { return nil }
+                  return gameCenterLeaderboardSetIds.contains(gameCenterLeaderboardSet.id) ? gameCenterLeaderboardSet : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboardSets
+    }
+
     public func getGameCenterLeaderboardSetsV2() -> [GameCenterLeaderboardSet] {
         guard let gameCenterLeaderboardSetsV2Ids = data.relationships?.gameCenterLeaderboardSetsV2?.data?.map(\.id),
               let gameCenterLeaderboardSetsV2 = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
@@ -95,6 +121,19 @@ public struct GameCenterGroupResponse: Codable, Sendable {
             return []
         }
         return gameCenterLeaderboardSetsV2
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboards() -> [GameCenterLeaderboard] {
+        guard let gameCenterLeaderboardIds = data.relationships?.gameCenterLeaderboards?.data?.map(\.id),
+              let gameCenterLeaderboards = included?.compactMap({ relationship -> GameCenterLeaderboard? in
+                  guard case let .gameCenterLeaderboard(gameCenterLeaderboard) = relationship else { return nil }
+                  return gameCenterLeaderboardIds.contains(gameCenterLeaderboard.id) ? gameCenterLeaderboard : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboards
     }
 
     public func getGameCenterLeaderboardsV2() -> [GameCenterLeaderboard] {

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterGroupsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterGroupsResponse.swift
@@ -44,6 +44,19 @@ public struct GameCenterGroupsResponse: Codable, Sendable, PagedResponse {
         try container.encodeIfPresent(meta, forKey: "meta")
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterAchievements(for gameCenterGroup: GameCenterGroup) -> [GameCenterAchievement] {
+        guard let gameCenterAchievementIds = gameCenterGroup.relationships?.gameCenterAchievements?.data?.map(\.id),
+              let gameCenterAchievements = included?.compactMap({ relationship -> GameCenterAchievement? in
+                  guard case let .gameCenterAchievement(gameCenterAchievement) = relationship else { return nil }
+                  return gameCenterAchievementIds.contains(gameCenterAchievement.id) ? gameCenterAchievement : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterAchievements
+    }
+
     public func getGameCenterAchievementsV2(for gameCenterGroup: GameCenterGroup) -> [GameCenterAchievement] {
         guard let gameCenterAchievementsV2Ids = gameCenterGroup.relationships?.gameCenterAchievementsV2?.data?.map(\.id),
               let gameCenterAchievementsV2 = included?.compactMap({ relationship -> GameCenterAchievement? in
@@ -92,6 +105,19 @@ public struct GameCenterGroupsResponse: Codable, Sendable, PagedResponse {
         return gameCenterDetails
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboardSets(for gameCenterGroup: GameCenterGroup) -> [GameCenterLeaderboardSet] {
+        guard let gameCenterLeaderboardSetIds = gameCenterGroup.relationships?.gameCenterLeaderboardSets?.data?.map(\.id),
+              let gameCenterLeaderboardSets = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
+                  guard case let .gameCenterLeaderboardSet(gameCenterLeaderboardSet) = relationship else { return nil }
+                  return gameCenterLeaderboardSetIds.contains(gameCenterLeaderboardSet.id) ? gameCenterLeaderboardSet : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboardSets
+    }
+
     public func getGameCenterLeaderboardSetsV2(for gameCenterGroup: GameCenterGroup) -> [GameCenterLeaderboardSet] {
         guard let gameCenterLeaderboardSetsV2Ids = gameCenterGroup.relationships?.gameCenterLeaderboardSetsV2?.data?.map(\.id),
               let gameCenterLeaderboardSetsV2 = included?.compactMap({ relationship -> GameCenterLeaderboardSet? in
@@ -102,6 +128,19 @@ public struct GameCenterGroupsResponse: Codable, Sendable, PagedResponse {
             return []
         }
         return gameCenterLeaderboardSetsV2
+    }
+
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGameCenterLeaderboards(for gameCenterGroup: GameCenterGroup) -> [GameCenterLeaderboard] {
+        guard let gameCenterLeaderboardIds = gameCenterGroup.relationships?.gameCenterLeaderboards?.data?.map(\.id),
+              let gameCenterLeaderboards = included?.compactMap({ relationship -> GameCenterLeaderboard? in
+                  guard case let .gameCenterLeaderboard(gameCenterLeaderboard) = relationship else { return nil }
+                  return gameCenterLeaderboardIds.contains(gameCenterLeaderboard.id) ? gameCenterLeaderboard : nil
+              })
+        else {
+            return []
+        }
+        return gameCenterLeaderboards
     }
 
     public func getGameCenterLeaderboardsV2(for gameCenterGroup: GameCenterGroup) -> [GameCenterLeaderboard] {

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardResponse.swift
@@ -77,6 +77,14 @@ public struct GameCenterLeaderboardResponse: Codable, Sendable {
         return gameCenterLeaderboardSets
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGroupLeaderboard() -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(groupLeaderboard) = relationship else { return nil }
+            return groupLeaderboard
+        }.first { $0.id == data.relationships?.groupLeaderboard?.data?.id }
+    }
+
     public func getLocalizations() -> [GameCenterLeaderboardLocalization] {
         guard let localizationIds = data.relationships?.localizations?.data?.map(\.id),
               let localizations = included?.compactMap({ relationship -> GameCenterLeaderboardLocalization? in

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetResponse.swift
@@ -63,6 +63,14 @@ public struct GameCenterLeaderboardSetResponse: Codable, Sendable {
         return gameCenterLeaderboards
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGroupLeaderboardSet() -> GameCenterLeaderboardSet? {
+        included?.compactMap { relationship -> GameCenterLeaderboardSet? in
+            guard case let .gameCenterLeaderboardSet(groupLeaderboardSet) = relationship else { return nil }
+            return groupLeaderboardSet
+        }.first { $0.id == data.relationships?.groupLeaderboardSet?.data?.id }
+    }
+
     public func getLocalizations() -> [GameCenterLeaderboardSetLocalization] {
         guard let localizationIds = data.relationships?.localizations?.data?.map(\.id),
               let localizations = included?.compactMap({ relationship -> GameCenterLeaderboardSetLocalization? in

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardSetsResponse.swift
@@ -70,6 +70,14 @@ public struct GameCenterLeaderboardSetsResponse: Codable, Sendable, PagedRespons
         return gameCenterLeaderboards
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGroupLeaderboardSet(for gameCenterLeaderboardSet: GameCenterLeaderboardSet) -> GameCenterLeaderboardSet? {
+        included?.compactMap { relationship -> GameCenterLeaderboardSet? in
+            guard case let .gameCenterLeaderboardSet(groupLeaderboardSet) = relationship else { return nil }
+            return groupLeaderboardSet
+        }.first { $0.id == gameCenterLeaderboardSet.relationships?.groupLeaderboardSet?.data?.id }
+    }
+
     public func getLocalizations(for gameCenterLeaderboardSet: GameCenterLeaderboardSet) -> [GameCenterLeaderboardSetLocalization] {
         guard let localizationIds = gameCenterLeaderboardSet.relationships?.localizations?.data?.map(\.id),
               let localizations = included?.compactMap({ relationship -> GameCenterLeaderboardSetLocalization? in

--- a/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardsResponse.swift
+++ b/Sources/Bagbutik-GameCenter/Models/GameCenterLeaderboardsResponse.swift
@@ -84,6 +84,14 @@ public struct GameCenterLeaderboardsResponse: Codable, Sendable, PagedResponse {
         return gameCenterLeaderboardSets
     }
 
+    @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+    public func getGroupLeaderboard(for gameCenterLeaderboard: GameCenterLeaderboard) -> GameCenterLeaderboard? {
+        included?.compactMap { relationship -> GameCenterLeaderboard? in
+            guard case let .gameCenterLeaderboard(groupLeaderboard) = relationship else { return nil }
+            return groupLeaderboard
+        }.first { $0.id == gameCenterLeaderboard.relationships?.groupLeaderboard?.data?.id }
+    }
+
     public func getLocalizations(for gameCenterLeaderboard: GameCenterLeaderboard) -> [GameCenterLeaderboardLocalization] {
         guard let localizationIds = gameCenterLeaderboard.relationships?.localizations?.data?.map(\.id),
               let localizations = included?.compactMap({ relationship -> GameCenterLeaderboardLocalization? in

--- a/Sources/BagbutikGenerator/Renderers/ObjectSchemaRenderer.swift
+++ b/Sources/BagbutikGenerator/Renderers/ObjectSchemaRenderer.swift
@@ -236,7 +236,7 @@ public class ObjectSchemaRenderer: Renderer {
         guard case .object(let dataSchema) = otherSchemas[dataSchemaName],
               case .schema(let relationshipsSchema) = dataSchema.properties["relationships"]?.type else { return [] }
         return relationshipsSchema.properties.sorted(by: { $0.key < $1.key }).compactMap { relationship -> String? in
-            guard !relationship.value.deprecated, case .schema(let relationshipPropertySchema) = relationship.value.type else { return nil }
+            guard case .schema(let relationshipPropertySchema) = relationship.value.type else { return nil }
             let pagedType = dataSchemaName.lowercasedFirstLetter()
             let relationshipDataProperty = relationshipPropertySchema.properties["data"]
             let relationshipDataSchema: ObjectSchema
@@ -313,7 +313,7 @@ public class ObjectSchemaRenderer: Renderer {
             }
             let functionName = "get\(relationship.key.capitalizingFirstLetter())"
             let returnType = isArrayReturnType ? "[\(includedSchemaName)]" : "\(includedSchemaName)?"
-            return renderFunction(named: functionName, parameters: parameters, returnType: returnType) {
+            return renderFunction(named: functionName, parameters: parameters, returnType: returnType, deprecated: relationship.value.deprecated) {
                 functionContent
             }
         }

--- a/Tests/BagbutikGeneratorTests/Renderers/ObjectSchemaRendererTests.swift
+++ b/Tests/BagbutikGeneratorTests/Renderers/ObjectSchemaRendererTests.swift
@@ -991,6 +991,19 @@ final class ObjectSchemaRendererTests: XCTestCase {
                 }.first { $0.id == build.relationships?.preReleaseVersion?.data?.id }
             }
 
+            @available(*, deprecated, message: "Apple has marked it as deprecated and it will be removed sometime in the future.")
+            public func getSomethingOld(for build: Build) -> [SomethingOld] {
+                guard let somethingOldIds = build.relationships?.somethingOld?.data?.map(\.id),
+                      let somethingOld = included?.compactMap({ relationship -> SomethingOld? in
+                          guard case let .somethingOld(somethingOld) = relationship else { return nil }
+                          return somethingOldIds.contains(somethingOld.id) ? somethingOld : nil
+                      })
+                else {
+                    return []
+                }
+                return somethingOld
+            }
+
             public enum Included: Codable, Sendable {
                 case betaTester(BetaTester)
                 case prereleaseVersion(PrereleaseVersion)


### PR DESCRIPTION
## Summary
* Restore included resource getters for deprecated relationships when the response included payload can contain the related resource.
* Mark restored getters as deprecated so callers still see Apple deprecation warnings.
* Regenerate the checked in models from openapi.oas.json.

## Root cause
The response generator skipped deprecated relationships before matching them against included resource types, even though the decoder and generated included enum still preserved those resources.

## Validation
* swift test --filter ObjectSchemaRendererTests
* swift test --filter BagbutikGeneratorTests
* swift build