### PR TITLE
Remove AppPriceV2InlineCreate schema patch

### DIFF
--- a/Sources/BagbutikSpecDecoder/Spec.swift
+++ b/Sources/BagbutikSpecDecoder/Spec.swift
@@ -323,53 +323,6 @@ public struct Spec: Decodable {
             addPatchedSchema(.object(appClipAdvancedExperienceUpdateRequestSchema), location: .topLevel(schemaName: "AppClipAdvancedExperienceUpdateRequest"))
         }
 
-        // Adds missing attributes and relationships to AppPriceV2InlineCreate.
-        // Apple's OpenAPI spec currently only includes `id` and `type`, which omits the payload
-        // used when creating manual app prices.
-        if case .object(var appPriceV2InlineCreateSchema) = components.schemas["AppPriceV2InlineCreate"] {
-            if appPriceV2InlineCreateSchema.properties["attributes"] == nil {
-                let attributesSchema = ObjectSchema(
-                    name: "Attributes",
-                    url: "\(appPriceV2InlineCreateSchema.url)/attributes",
-                    properties: [
-                        "startDate": .init(type: .simple(.string())),
-                        "endDate": .init(type: .simple(.string()))
-                    ]
-                )
-                appPriceV2InlineCreateSchema.properties["attributes"] = .init(type: .schema(attributesSchema))
-            }
-            if appPriceV2InlineCreateSchema.properties["relationships"] == nil {
-                let appPricePointDataSchema = ObjectSchema(
-                    name: "Data",
-                    url: "\(appPriceV2InlineCreateSchema.url)/relationships/appPricePoint/data",
-                    properties: [
-                        "type": .init(type: .constant("appPricePoints")),
-                        "id": .init(type: .simple(.string()))
-                    ],
-                    requiredProperties: ["type", "id"]
-                )
-                let appPricePointSchema = ObjectSchema(
-                    name: "AppPricePoint",
-                    url: "\(appPriceV2InlineCreateSchema.url)/relationships/appPricePoint",
-                    properties: [
-                        "data": .init(type: .schema(appPricePointDataSchema))
-                    ],
-                    requiredProperties: ["data"]
-                )
-                let relationshipsSchema = ObjectSchema(
-                    name: "Relationships",
-                    url: "\(appPriceV2InlineCreateSchema.url)/relationships",
-                    properties: [
-                        "appPricePoint": .init(type: .schema(appPricePointSchema))
-                    ],
-                    requiredProperties: ["appPricePoint"]
-                )
-                appPriceV2InlineCreateSchema.properties["relationships"] = .init(type: .schema(relationshipsSchema))
-            }
-            components.schemas["AppPriceV2InlineCreate"] = .object(appPriceV2InlineCreateSchema)
-            addPatchedSchema(.object(appPriceV2InlineCreateSchema), location: .topLevel(schemaName: "AppPriceV2InlineCreate"))
-        }
-
         // FB16908301: Adds list of `PurchaseRequirement` to `AppEvent`.
         if case .object(var appEventSchema) = components.schemas["AppEvent"] {
             if case.schema(var appEventAttributesSchema) = appEventSchema.properties["attributes"]?.type,

--- a/Tests/BagbutikSpecDecoderTests/SpecTests.swift
+++ b/Tests/BagbutikSpecDecoderTests/SpecTests.swift
@@ -758,19 +758,6 @@ final class SpecTests: XCTestCase {
                         },
                         "required" : [ "data" ]
                     },
-                    "AppPriceV2InlineCreate" : {
-                        "type" : "object",
-                        "title" : "AppPriceV2InlineCreate",
-                        "properties" : {
-                            "id" : {
-                                "type" : "string"
-                            },
-                            "type" : {
-                                "type" : "string",
-                                "enum" : [ "appPrices" ]
-                            }
-                        }
-                    },
                     "AppEvent" : {
                         "type" : "object",
                         "title" : "AppEvent",
@@ -891,24 +878,6 @@ final class SpecTests: XCTestCase {
         }
         XCTAssertTrue(businessCategoryProperty.clearable)
         XCTAssertTrue(placeProperty.clearable)
-
-        guard case .object(let appPriceV2InlineCreateSchema) = spec.components.schemas["AppPriceV2InlineCreate"],
-              case .schema(let appPriceV2InlineCreateAttributesSchema) = appPriceV2InlineCreateSchema.properties["attributes"]?.type,
-              case .schema(let appPriceV2InlineCreateRelationshipsSchema) = appPriceV2InlineCreateSchema.properties["relationships"]?.type,
-              case .schema(let appPricePointSchema) = appPriceV2InlineCreateRelationshipsSchema.properties["appPricePoint"]?.type,
-              case .schema(let appPricePointDataSchema) = appPricePointSchema.properties["data"]?.type,
-              case .constant(let appPricePointType) = appPricePointDataSchema.properties["type"]?.type,
-              case .simple(let startDateType) = appPriceV2InlineCreateAttributesSchema.properties["startDate"]?.type,
-              case .simple(let endDateType) = appPriceV2InlineCreateAttributesSchema.properties["endDate"]?.type
-        else {
-            XCTFail(); return
-        }
-        XCTAssertEqual(startDateType, .string())
-        XCTAssertEqual(endDateType, .string())
-        XCTAssertEqual(appPricePointType, "appPricePoints")
-        XCTAssertEqual(appPriceV2InlineCreateRelationshipsSchema.requiredProperties, ["appPricePoint"])
-        XCTAssertEqual(appPricePointSchema.requiredProperties, ["data"])
-        XCTAssertEqual(appPricePointDataSchema.requiredProperties, ["type", "id"])
 
         guard case .object(let appEventSchema) = spec.components.schemas["AppEvent"],
               case .schema(let appEventAttributesSchema) = appEventSchema.properties["attributes"]?.type,


### PR DESCRIPTION
Delete the workaround in Sources/BagbutikSpecDecoder/Spec.swift that injected missing attributes and relationships into the AppPriceV2InlineCreate schema. The removed code previously built attributes (startDate, endDate) and a relationships/appPricePoint structure (type/id), updated components.schemas, and registered the patched schema via addPatchedSchema.