### PR TITLE
Add the BagbutikUsers architecture slice

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Bagbutik-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Bagbutik-Package.xcscheme
@@ -210,9 +210,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "system-zlib"
-               BuildableName = "system-zlib"
-               BlueprintName = "system-zlib"
+               BlueprintIdentifier = "Bagbutik-Core"
+               BuildableName = "Bagbutik-Core"
+               BlueprintName = "Bagbutik-Core"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -224,9 +224,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Bagbutik-Core"
-               BuildableName = "Bagbutik-Core"
-               BlueprintName = "Bagbutik-Core"
+               BlueprintIdentifier = "system-zlib"
+               BuildableName = "system-zlib"
+               BlueprintName = "system-zlib"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -283,20 +283,6 @@
                BlueprintIdentifier = "Bagbutik-XcodeCloud"
                BuildableName = "Bagbutik-XcodeCloud"
                BlueprintName = "Bagbutik-XcodeCloud"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Bagbutik-Users"
-               BuildableName = "Bagbutik-Users"
-               BlueprintName = "Bagbutik-Users"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -367,6 +353,34 @@
                BlueprintIdentifier = "Bagbutik-Webhooks"
                BuildableName = "Bagbutik-Webhooks"
                BlueprintName = "Bagbutik-Webhooks"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BagbutikCore"
+               BuildableName = "BagbutikCore"
+               BlueprintName = "BagbutikCore"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BagbutikUsers"
+               BuildableName = "BagbutikUsers"
+               BlueprintName = "BagbutikUsers"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -451,6 +465,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BagbutikUsersIntegrationTests"
+               BuildableName = "BagbutikUsersIntegrationTests"
+               BlueprintName = "BagbutikUsersIntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -490,6 +514,15 @@
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "bagbutik-cli"
+            BuildableName = "bagbutik-cli"
+            BlueprintName = "bagbutik-cli"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Package.swift
+++ b/Package.swift
@@ -13,24 +13,11 @@ let package = Package(
     ],
     products: [
         .library(
-            // Includes all targets. Each target still needs to be imported in code.
-            name: "Bagbutik",
-            targets: [
-                "Bagbutik-Core",
-                "Bagbutik-Models",
-                "Bagbutik-AppStore",
-                "Bagbutik-GameCenter",
-                "Bagbutik-Marketplaces",
-                "Bagbutik-Provisioning",
-                "Bagbutik-Reporting",
-                "Bagbutik-TestFlight",
-                "Bagbutik-Users",
-                "Bagbutik-Webhooks",
-                "Bagbutik-XcodeCloud",
-            ]
+            name: "BagbutikCore",
+            targets: ["BagbutikCore"]
         ),
         .library(
-            // Has the core features like the service, JWT and general models.
+            // Preserves the legacy module import while API products migrate.
             name: "Bagbutik-Core",
             targets: ["Bagbutik-Core"]
         ),
@@ -64,8 +51,13 @@ let package = Package(
             targets: ["Bagbutik-TestFlight"]
         ),
         .library(
-            name: "Bagbutik-Users",
-            targets: ["Bagbutik-Users"]
+            name: "BagbutikUsers",
+            targets: [
+                "BagbutikCore",
+                "BagbutikModelsShared",
+                "BagbutikUsersModels",
+                "BagbutikUsers",
+            ]
         ),
         .library(
             name: "Bagbutik-Webhooks",
@@ -80,18 +72,33 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto", from: "3.12.3"),
     ],
     targets: [
-        .target(name: "Bagbutik-Core", dependencies: [
-            .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux, .android])),
-            .target(name: "system-zlib", condition: .when(platforms: [.linux, .android]))
-        ]),
-        .target(name: "Bagbutik-Models", dependencies: ["Bagbutik-Core"]),
+        .target(
+            name: "BagbutikCore",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux, .android])),
+                .target(name: "system-zlib", condition: .when(platforms: [.linux, .android]))
+            ],
+            path: "Sources/Bagbutik-Core"
+        ),
+        .target(
+            name: "Bagbutik-Core",
+            dependencies: ["BagbutikCore"],
+            path: "Sources/Bagbutik-CoreCompatibility"
+        ),
+        .target(name: "BagbutikModelsShared", dependencies: ["BagbutikCore"]),
+        .target(name: "BagbutikUsersModels", dependencies: ["BagbutikCore", "BagbutikModelsShared"]),
+        .target(
+            name: "BagbutikUsers",
+            dependencies: ["BagbutikCore", "BagbutikModelsShared", "BagbutikUsersModels"],
+            path: "Sources/Bagbutik-Users"
+        ),
+        .target(name: "Bagbutik-Models", dependencies: ["Bagbutik-Core", "BagbutikModelsShared", "BagbutikUsersModels"]),
         .target(name: "Bagbutik-AppStore", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "Bagbutik-GameCenter", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "Bagbutik-Marketplaces", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "Bagbutik-Provisioning", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "Bagbutik-Reporting", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "Bagbutik-TestFlight", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
-        .target(name: "Bagbutik-Users", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "Bagbutik-Webhooks", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "Bagbutik-XcodeCloud", dependencies: ["Bagbutik-Core", "Bagbutik-Models"]),
         .target(name: "system-zlib"),
@@ -106,6 +113,10 @@ let package = Package(
             resources: [.copy("test-private-key.p8")]
         ),
         .testTarget(name: "Bagbutik-ModelsTests", dependencies: ["Bagbutik-Models"]),
+        .testTarget(
+            name: "BagbutikUsersIntegrationTests",
+            dependencies: ["BagbutikCore", "BagbutikModelsShared", "BagbutikUsersModels", "BagbutikUsers"]
+        ),
     ],
     swiftLanguageModes: [.v5, .v6]
 )

--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ print(response)
 
 The repository is split into a small manually maintained core and a large generated API surface.
 
-* `Bagbutik-Core` contains the request service, JWT support, shared response protocols, and the common models used across all API areas.
-* `Bagbutik-Models` contains generated shared models that are referenced by more than one API area.
+* `BagbutikCore` contains the request service, JWT support, shared response protocols, and the common models used across all API areas.
+* `BagbutikModelsShared` contains the small generated model groups shared by public API products.
+* `BagbutikUsersModels` and similar model modules are generated from actual schema references for their public API product.
 * `Bagbutik-AppStore`, `Bagbutik-TestFlight`, `Bagbutik-Reporting`, and the other product modules contain generated endpoint builders grouped by App Store Connect domain.
 * `Tools/Sources/BagbutikSpecDecoder` decodes Apple's OpenAPI document into an intermediate Swift representation.
 * `Tools/Sources/BagbutikDocsCollector` downloads and normalizes Apple documentation so generated code gets useful Xcode documentation comments.
 * `Tools/Sources/BagbutikGenerator` combines the decoded spec and collected docs to render the Swift source in `Sources/`.
 
-This split matters when navigating the codebase. If you want to understand runtime behavior, start in `Bagbutik-Core`. If you want to understand how generated endpoints and models are produced, start with the nested `Tools` package.
+This split matters when navigating the codebase. If you want to understand runtime behavior, start in the `Sources/Bagbutik-Core` folder. If you want to understand how generated endpoints and models are produced, start with the nested `Tools` package.
 
 ## How to get Bagbutik into a project
 
@@ -98,22 +99,12 @@ Then add the required products to your target:
 .target(
     name: "Awesome",
     dependencies: [
-        .product(name: "Bagbutik-AppStore", package: "Bagbutik"),
-        .product(name: "Bagbutik-TestFlight", package: "Bagbutik"),
+        .product(name: "BagbutikUsers", package: "Bagbutik"),
     ]
 )
 ```
 
-If you need access to all APIs, you can depend on the umbrella library:
-
-```swift
-.target(
-    name: "Awesome",
-    dependencies: [
-        .product(name: "Bagbutik", package: "Bagbutik"),
-    ]
-)
-```
+Select each public product your application uses. Bagbutik intentionally has no umbrella product because selecting it would compile every API area.
 
 #### Available modules
 
@@ -125,11 +116,11 @@ Each module corresponds to a specific area of the App Store Connect API:
 * `Bagbutik-Provisioning`: Manage the [bundle IDs](https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids), [certificates](https://developer.apple.com/documentation/appstoreconnectapi/certificates), [devices](https://developer.apple.com/documentation/appstoreconnectapi/devices) and [provisioning profiles](https://developer.apple.com/documentation/appstoreconnectapi/profiles) for your app.
 * `Bagbutik-Reporting`: Download your [sales and financial reports](https://developer.apple.com/documentation/appstoreconnectapi/sales_and_finance_reports) and [get power and performance metrics, logs, and signatures](https://developer.apple.com/documentation/appstoreconnectapi/power_and_performance_metrics_and_logs). 
 * `Bagbutik-TestFlight`: Manage your [beta testing program, including beta testers and groups, apps, App Clips, and builds](https://developer.apple.com/documentation/appstoreconnectapi/prerelease_versions_and_beta_testers).
-* `Bagbutik-Users`: Manage [users](https://developer.apple.com/documentation/appstoreconnectapi/users) and [email invitations to join](https://developer.apple.com/documentation/appstoreconnectapi/user_invitations) your App Store Connect team.
+* `BagbutikUsers`: Manage [users](https://developer.apple.com/documentation/appstoreconnectapi/users) and [email invitations to join](https://developer.apple.com/documentation/appstoreconnectapi/user_invitations) your App Store Connect team.
 * `Bagbutik-Webhooks`: Manage [notifications](https://developer.apple.com/documentation/appstoreconnectapi/webhook-notifications) from App Store about your apps and their statuses.
 * `Bagbutik-XcodeCloud`: Automate [reading Xcode Cloud data, managing workflows, and starting builds](https://developer.apple.com/documentation/appstoreconnectapi/xcode_cloud_workflows_and_builds).
 
-Remember to replace hyphens with underscores when importing modules.
+For the remaining products with hyphens, replace hyphens with underscores when importing modules.
 For example, when importing `Bagbutik-TestFlight`:
 
 `import Bagbutik_TestFlight`
@@ -138,7 +129,7 @@ For example, when importing `Bagbutik-TestFlight`:
 
 Generated endpoints follow the same pattern throughout the package:
 
-1. Import `Bagbutik_Core` and the product module for the API area you need.
+1. Import the Core module and the product module for the API area you need. Migrated products use `BagbutikCore`; remaining legacy products use `Bagbutik_Core`.
 2. Build a `Request` by calling a generated static helper such as `.listBundleIdsV1(...)`.
 3. Send the request through `BagbutikService`.
 4. If the response type supports pagination, use `requestNextPage(for:)` or `requestAllPages(_:)`.

--- a/Sources/Bagbutik-CoreCompatibility/Exports.swift
+++ b/Sources/Bagbutik-CoreCompatibility/Exports.swift
@@ -1,0 +1,2 @@
+// Preserves `import Bagbutik_Core` until every API product has migrated.
+@_exported import BagbutikCore

--- a/Sources/Bagbutik-Models/Extensions/UserRole+PrettyName.swift
+++ b/Sources/Bagbutik-Models/Extensions/UserRole+PrettyName.swift
@@ -1,3 +1,5 @@
+import BagbutikUsersModels
+
 public extension UserRole {
     /// A pretty name for the case. The names are added as best effort, and a better name could exist.
     var prettyName: String {

--- a/Sources/Bagbutik-Models/LegacyModelExports.swift
+++ b/Sources/Bagbutik-Models/LegacyModelExports.swift
@@ -1,0 +1,2 @@
+@_exported import BagbutikModelsShared
+@_exported import BagbutikUsersModels

--- a/Sources/Bagbutik-Users/Endpoints/User/DeleteUserV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/User/DeleteUserV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/Bagbutik-Users/Endpoints/User/GetUserV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/User/GetUserV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/Bagbutik-Users/Endpoints/User/ListUsersV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/User/ListUsersV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/Bagbutik-Users/Endpoints/User/UpdateUserV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/User/UpdateUserV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/Bagbutik-Users/Endpoints/UserInvitation/CreateUserInvitationV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/UserInvitation/CreateUserInvitationV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/Bagbutik-Users/Endpoints/UserInvitation/DeleteUserInvitationV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/UserInvitation/DeleteUserInvitationV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/Bagbutik-Users/Endpoints/UserInvitation/GetUserInvitationV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/UserInvitation/GetUserInvitationV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/Bagbutik-Users/Endpoints/UserInvitation/ListUserInvitationsV1.swift
+++ b/Sources/Bagbutik-Users/Endpoints/UserInvitation/ListUserInvitationsV1.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikUsersModels
 
 public extension Request {
     /**

--- a/Sources/BagbutikModelsShared/App.swift
+++ b/Sources/BagbutikModelsShared/App.swift
@@ -1,4 +1,4 @@
-import Bagbutik_Core
+import BagbutikCore
 import Foundation
 
 /**

--- a/Sources/BagbutikModelsShared/SubscriptionStatusUrlVersion.swift
+++ b/Sources/BagbutikModelsShared/SubscriptionStatusUrlVersion.swift
@@ -1,4 +1,4 @@
-import Bagbutik_Core
+import BagbutikCore
 import Foundation
 
 public enum SubscriptionStatusUrlVersion: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikUsersModels/User.swift
+++ b/Sources/BagbutikUsersModels/User.swift
@@ -1,20 +1,21 @@
-import Bagbutik_Core
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**
- # UserInvitation
- A pending invitation for a person to join your App Store Connect team with a specified role and app access.
+ # User
+ A member of your App Store Connect team, with assigned roles and access to specific apps.
 
  Full documentation:
- <https://developer.apple.com/documentation/appstoreconnectapi/userinvitation>
+ <https://developer.apple.com/documentation/appstoreconnectapi/user>
  */
-public struct UserInvitation: Codable, Sendable, Identifiable {
+public struct User: Codable, Sendable, Identifiable {
     /// The opaque resource ID that uniquely identifies the resource.
     public let id: String
     /// Navigational links that include the self-link.
     public var links: ResourceLinks?
     /// The resource type.
-    public var type: String { "userInvitations" }
+    public var type: String { "users" }
     /// The resource’s attributes.
     public var attributes: Attributes?
     /// Navigational links to related data and included resource types and IDs.
@@ -53,50 +54,45 @@ public struct UserInvitation: Codable, Sendable, Identifiable {
 
     public struct Attributes: Codable, Sendable {
         public var allAppsVisible: Bool?
-        public var email: String?
-        public var expirationDate: Date?
         public var firstName: String?
         public var lastName: String?
         public var provisioningAllowed: Bool?
         public var roles: [UserRole]?
+        public var username: String?
 
         public init(allAppsVisible: Bool? = nil,
-                    email: String? = nil,
-                    expirationDate: Date? = nil,
                     firstName: String? = nil,
                     lastName: String? = nil,
                     provisioningAllowed: Bool? = nil,
-                    roles: [UserRole]? = nil)
+                    roles: [UserRole]? = nil,
+                    username: String? = nil)
         {
             self.allAppsVisible = allAppsVisible
-            self.email = email
-            self.expirationDate = expirationDate
             self.firstName = firstName
             self.lastName = lastName
             self.provisioningAllowed = provisioningAllowed
             self.roles = roles
+            self.username = username
         }
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: AnyCodingKey.self)
             allAppsVisible = try container.decodeIfPresent(Bool.self, forKey: "allAppsVisible")
-            email = try container.decodeIfPresent(String.self, forKey: "email")
-            expirationDate = try container.decodeIfPresent(Date.self, forKey: "expirationDate")
             firstName = try container.decodeIfPresent(String.self, forKey: "firstName")
             lastName = try container.decodeIfPresent(String.self, forKey: "lastName")
             provisioningAllowed = try container.decodeIfPresent(Bool.self, forKey: "provisioningAllowed")
             roles = try container.decodeIfPresent([UserRole].self, forKey: "roles")
+            username = try container.decodeIfPresent(String.self, forKey: "username")
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: AnyCodingKey.self)
             try container.encodeIfPresent(allAppsVisible, forKey: "allAppsVisible")
-            try container.encodeIfPresent(email, forKey: "email")
-            try container.encodeIfPresent(expirationDate, forKey: "expirationDate")
             try container.encodeIfPresent(firstName, forKey: "firstName")
             try container.encodeIfPresent(lastName, forKey: "lastName")
             try container.encodeIfPresent(provisioningAllowed, forKey: "provisioningAllowed")
             try container.encodeIfPresent(roles, forKey: "roles")
+            try container.encodeIfPresent(username, forKey: "username")
         }
     }
 

--- a/Sources/BagbutikUsersModels/UserInvitation.swift
+++ b/Sources/BagbutikUsersModels/UserInvitation.swift
@@ -1,20 +1,21 @@
-import Bagbutik_Core
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**
- # User
- A member of your App Store Connect team, with assigned roles and access to specific apps.
+ # UserInvitation
+ A pending invitation for a person to join your App Store Connect team with a specified role and app access.
 
  Full documentation:
- <https://developer.apple.com/documentation/appstoreconnectapi/user>
+ <https://developer.apple.com/documentation/appstoreconnectapi/userinvitation>
  */
-public struct User: Codable, Sendable, Identifiable {
+public struct UserInvitation: Codable, Sendable, Identifiable {
     /// The opaque resource ID that uniquely identifies the resource.
     public let id: String
     /// Navigational links that include the self-link.
     public var links: ResourceLinks?
     /// The resource type.
-    public var type: String { "users" }
+    public var type: String { "userInvitations" }
     /// The resource’s attributes.
     public var attributes: Attributes?
     /// Navigational links to related data and included resource types and IDs.
@@ -53,45 +54,50 @@ public struct User: Codable, Sendable, Identifiable {
 
     public struct Attributes: Codable, Sendable {
         public var allAppsVisible: Bool?
+        public var email: String?
+        public var expirationDate: Date?
         public var firstName: String?
         public var lastName: String?
         public var provisioningAllowed: Bool?
         public var roles: [UserRole]?
-        public var username: String?
 
         public init(allAppsVisible: Bool? = nil,
+                    email: String? = nil,
+                    expirationDate: Date? = nil,
                     firstName: String? = nil,
                     lastName: String? = nil,
                     provisioningAllowed: Bool? = nil,
-                    roles: [UserRole]? = nil,
-                    username: String? = nil)
+                    roles: [UserRole]? = nil)
         {
             self.allAppsVisible = allAppsVisible
+            self.email = email
+            self.expirationDate = expirationDate
             self.firstName = firstName
             self.lastName = lastName
             self.provisioningAllowed = provisioningAllowed
             self.roles = roles
-            self.username = username
         }
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: AnyCodingKey.self)
             allAppsVisible = try container.decodeIfPresent(Bool.self, forKey: "allAppsVisible")
+            email = try container.decodeIfPresent(String.self, forKey: "email")
+            expirationDate = try container.decodeIfPresent(Date.self, forKey: "expirationDate")
             firstName = try container.decodeIfPresent(String.self, forKey: "firstName")
             lastName = try container.decodeIfPresent(String.self, forKey: "lastName")
             provisioningAllowed = try container.decodeIfPresent(Bool.self, forKey: "provisioningAllowed")
             roles = try container.decodeIfPresent([UserRole].self, forKey: "roles")
-            username = try container.decodeIfPresent(String.self, forKey: "username")
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: AnyCodingKey.self)
             try container.encodeIfPresent(allAppsVisible, forKey: "allAppsVisible")
+            try container.encodeIfPresent(email, forKey: "email")
+            try container.encodeIfPresent(expirationDate, forKey: "expirationDate")
             try container.encodeIfPresent(firstName, forKey: "firstName")
             try container.encodeIfPresent(lastName, forKey: "lastName")
             try container.encodeIfPresent(provisioningAllowed, forKey: "provisioningAllowed")
             try container.encodeIfPresent(roles, forKey: "roles")
-            try container.encodeIfPresent(username, forKey: "username")
         }
     }
 

--- a/Sources/BagbutikUsersModels/UserInvitationCreateRequest.swift
+++ b/Sources/BagbutikUsersModels/UserInvitationCreateRequest.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UserInvitationResponse.swift
+++ b/Sources/BagbutikUsersModels/UserInvitationResponse.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UserInvitationsResponse.swift
+++ b/Sources/BagbutikUsersModels/UserInvitationsResponse.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UserResponse.swift
+++ b/Sources/BagbutikUsersModels/UserResponse.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UserRole.swift
+++ b/Sources/BagbutikUsersModels/UserRole.swift
@@ -1,4 +1,5 @@
-import Bagbutik_Core
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 public enum UserRole: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikUsersModels/UserUpdateRequest.swift
+++ b/Sources/BagbutikUsersModels/UserUpdateRequest.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UsersResponse.swift
+++ b/Sources/BagbutikUsersModels/UsersResponse.swift
@@ -1,5 +1,5 @@
-import Bagbutik_Core
-import Bagbutik_Models
+import BagbutikCore
+import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Tests/Bagbutik-CoreTests/BagbutikServiceTests.swift
+++ b/Tests/Bagbutik-CoreTests/BagbutikServiceTests.swift
@@ -1,5 +1,5 @@
 import Bagbutik_AppStore
-@testable import Bagbutik_Core
+@testable import BagbutikCore
 import Bagbutik_Models
 import XCTest
 #if canImport(FoundationNetworking)

--- a/Tests/Bagbutik-CoreTests/ClearableTests.swift
+++ b/Tests/Bagbutik-CoreTests/ClearableTests.swift
@@ -1,4 +1,4 @@
-@testable import Bagbutik_Core
+@testable import BagbutikCore
 import XCTest
 
 final class ClearableTests: XCTestCase {

--- a/Tests/Bagbutik-CoreTests/EndpointParameterTests.swift
+++ b/Tests/Bagbutik-CoreTests/EndpointParameterTests.swift
@@ -1,4 +1,4 @@
-@testable import Bagbutik_Core
+@testable import BagbutikCore
 import XCTest
 
 final class EndpointParameterTests: XCTestCase {

--- a/Tests/Bagbutik-CoreTests/GunzipTests.swift
+++ b/Tests/Bagbutik-CoreTests/GunzipTests.swift
@@ -1,4 +1,4 @@
-@testable import Bagbutik_Core
+@testable import BagbutikCore
 import XCTest
 #if os(Linux) || os(Android) || os(Windows)
 import zlibLinux

--- a/Tests/Bagbutik-CoreTests/JWTTests.swift
+++ b/Tests/Bagbutik-CoreTests/JWTTests.swift
@@ -1,4 +1,4 @@
-@testable import Bagbutik_Core
+@testable import BagbutikCore
 import XCTest
 
 final class JWTTests: XCTestCase {

--- a/Tests/Bagbutik-CoreTests/NullCodableTests.swift
+++ b/Tests/Bagbutik-CoreTests/NullCodableTests.swift
@@ -1,4 +1,4 @@
-@testable import Bagbutik_Core
+@testable import BagbutikCore
 import XCTest
 
 final class NullCodableTests: XCTestCase {

--- a/Tests/Bagbutik-CoreTests/RequestTests.swift
+++ b/Tests/Bagbutik-CoreTests/RequestTests.swift
@@ -1,4 +1,4 @@
-@testable import Bagbutik_Core
+@testable import BagbutikCore
 import XCTest
 
 final class RequestTests: XCTestCase {

--- a/Tests/BagbutikUsersIntegrationTests/BagbutikUsersIntegrationTests.swift
+++ b/Tests/BagbutikUsersIntegrationTests/BagbutikUsersIntegrationTests.swift
@@ -1,0 +1,60 @@
+import BagbutikCore
+import BagbutikModelsShared
+import BagbutikUsers
+import BagbutikUsersModels
+import Foundation
+import XCTest
+
+final class BagbutikUsersIntegrationTests: XCTestCase {
+    func testPublicUsersRequestHasExpectedEndpoint() {
+        let request = Request<UsersResponse, ErrorResponse>.listUsersV1(
+            filters: [.roles([.admin])],
+            includes: [.visibleApps],
+            sorts: [.usernameAscending],
+            limits: [.limit(20)]
+        )
+
+        XCTAssertEqual(request.path, "/v1/users")
+        XCTAssertEqual(request.method, .get)
+    }
+
+    func testUsersResponseDecodesIncludedVisibleApps() throws {
+        let json = #"""
+        {
+          "data": [
+            {
+              "type": "users",
+              "id": "user-1",
+              "attributes": {
+                "firstName": "Ada",
+                "lastName": "Lovelace",
+                "roles": ["ADMIN"]
+              },
+              "relationships": {
+                "visibleApps": {
+                  "data": [{ "type": "apps", "id": "app-1" }]
+                }
+              }
+            }
+          ],
+          "included": [
+            {
+              "type": "apps",
+              "id": "app-1",
+              "attributes": {
+                "name": "Analytical Engine",
+                "subscriptionStatusUrlVersion": "V2"
+              }
+            }
+          ],
+          "links": { "self": "https://api.appstoreconnect.apple.com/v1/users" }
+        }
+        """#
+
+        let response = try JSONDecoder().decode(UsersResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.data.first?.attributes?.roles, [.admin])
+        XCTAssertEqual(response.getVisibleApps(for: response.data[0]).first?.attributes?.name, "Analytical Engine")
+        XCTAssertEqual(response.included?.first?.attributes?.subscriptionStatusUrlVersion, .V2)
+    }
+}

--- a/Tools/Sources/BagbutikDocsCollector/Models/PackageName.swift
+++ b/Tools/Sources/BagbutikDocsCollector/Models/PackageName.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum PackageName: CaseIterable, Codable, Equatable {
+public enum PackageName: CaseIterable, Codable, Equatable, Sendable {
     case appStore
     case core
     case gameCenter

--- a/Tools/Sources/BagbutikGenerator/Generator.swift
+++ b/Tools/Sources/BagbutikGenerator/Generator.swift
@@ -82,6 +82,16 @@ public class Generator {
         try await docsLoader.loadDocs(documentationDirURL: documentationDirURL)
         try await docsLoader.applyManualDocumentation()
 
+        let schemas = spec.components.schemas
+        var packageBySchema = [String: PackageName]()
+        for schema in schemas.values {
+            packageBySchema[schema.name] = try await Self.resolvePackageName(for: schema, docsLoader: docsLoader)
+        }
+        let modulePlan = RuntimeModulePlan(
+            usersSliceFrom: SchemaReferenceGraph(schemas: schemas),
+            packageBySchema: packageBySchema
+        )
+
         let generalModelsDirURL = outputDirURL.appendingPathComponent("Bagbutik-Models")
         for packageName in PackageName.allCases {
             let packageDirURL = outputDirURL.appendingPathComponent(packageName.name)
@@ -100,6 +110,11 @@ public class Generator {
             try removeChildren(at: generalModelsDirURL.appendingPathComponent(packageName.docsSectionName))
             try fileManager.createDirectory(at: generalModelsDirURL, withIntermediateDirectories: true, attributes: nil)
         }
+        for generatedModelsDirectory in ["BagbutikModelsShared", "BagbutikUsersModels"] {
+            let directoryURL = outputDirURL.appendingPathComponent(generatedModelsDirectory)
+            try removeChildren(at: directoryURL)
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
+        }
 
         try await withThrowingTaskGroup(of: [RenderResult].self) { taskGroup in
             for path in spec.paths.values {
@@ -117,7 +132,12 @@ public class Generator {
                         } else {
                             throw GeneratorError.noDocumentationForOperation(operation.id)
                         }
-                        let renderedOperation = try await operationRenderer.render(operation: operation, in: path) + "\n"
+                        var renderedOperation = try await operationRenderer.render(operation: operation, in: path) + "\n"
+                        if packageName == .users {
+                            renderedOperation = renderedOperation
+                                .replacingOccurrences(of: "import Bagbutik_Core", with: "import BagbutikCore")
+                                .replacingOccurrences(of: "import Bagbutik_Models", with: "import BagbutikUsersModels")
+                        }
                         let packageDirURL = outputDirURL.appendingPathComponent(packageName.name).appendingPathComponent("Endpoints")
                         let operationDirURL = Self.getOperationsDirURL(for: path, in: packageDirURL)
                         renderResults.append(.init(dirURL: operationDirURL, name: name, fileName: fileName, contents: renderedOperation))
@@ -138,21 +158,24 @@ public class Generator {
         }
 
         try await withThrowingTaskGroup(of: RenderResult.self) { taskGroup in
-            let schemas = spec.components.schemas
             for schema in schemas.values {
-                taskGroup.addTask { [docsLoader, schemas] in
-                    let packageName: PackageName
-                    if let documentation = try await docsLoader.resolveDocumentationForSchema(named: schema.name) {
-                        packageName = try DocsLoader.resolvePackageName(for: documentation)
-                    } else if let inferredPackageName = DocsLoader.resolvePackageName(from: schema.name) {
-                        packageName = inferredPackageName
-                    } else {
-                        throw GeneratorError.noDocumentationForSchema(schema.name)
-                    }
-                    let model = try await Generator.generateModel(for: schema, packageName: packageName, otherSchemas: schemas, docsLoader: docsLoader)
+                taskGroup.addTask { [docsLoader, schemas, packageBySchema, modulePlan] in
+                    let packageName = packageBySchema[schema.name]!
+                    let modelModule = modulePlan[schema.name]
+                    let model = try await Generator.generateModel(
+                        for: schema,
+                        packageName: packageName,
+                        modelModule: modelModule,
+                        otherSchemas: schemas,
+                        docsLoader: docsLoader
+                    )
                     let fileName = model.name + ".swift"
 
-                    let modelsDirURL: URL = if schema.name.hasSuffix("LinkagesRequest") || schema.name.hasSuffix("LinkageRequest") {
+                    let modelsDirURL: URL = if modelModule == .modelsShared {
+                        outputDirURL.appendingPathComponent("BagbutikModelsShared")
+                    } else if modelModule == .usersModels {
+                        outputDirURL.appendingPathComponent("BagbutikUsersModels")
+                    } else if schema.name.hasSuffix("LinkagesRequest") || schema.name.hasSuffix("LinkageRequest") {
                         outputDirURL
                             .appendingPathComponent("Bagbutik-Models")
                             .appendingPathComponent("LinkageRequests")
@@ -206,6 +229,16 @@ public class Generator {
         return operationsDirURL.appendingPathComponent("Relationships")
     }
 
+    private static func resolvePackageName(for schema: Schema, docsLoader: DocsLoader) async throws -> PackageName {
+        if let documentation = try await docsLoader.resolveDocumentationForSchema(named: schema.name) {
+            return try DocsLoader.resolvePackageName(for: documentation)
+        }
+        if let inferredPackageName = DocsLoader.resolvePackageName(from: schema.name) {
+            return inferredPackageName
+        }
+        throw GeneratorError.noDocumentationForSchema(schema.name)
+    }
+
     /**
      Renders one schema into the generated Swift source for the appropriate package.
 
@@ -216,7 +249,13 @@ public class Generator {
         - docsLoader: The documentation loader used to resolve symbol comments.
      - Returns: The rendered model name, its full file contents, and the original schema documentation URL.
      */
-    static func generateModel(for schema: Schema, packageName: PackageName, otherSchemas: [String: Schema], docsLoader: DocsLoader)
+    static func generateModel(
+        for schema: Schema,
+        packageName: PackageName,
+        modelModule: RuntimeModulePlan.ModelModule? = nil,
+        otherSchemas: [String: Schema],
+        docsLoader: DocsLoader
+    )
         async throws -> (name: String, contents: String, url: String?) {
         let renderedSchema: String = switch schema {
         case .enum(let enumSchema):
@@ -233,14 +272,24 @@ public class Generator {
                 .render(plainTextSchema: plainTextSchema)
         }
         var imports = ["import Foundation"]
-        if packageName != .core {
-            imports.append("import Bagbutik_Core")
-            if schema.name.hasSuffix("Request") || schema.name.hasSuffix("Response") {
-                imports.append("import Bagbutik_Models")
+        switch modelModule {
+        case .modelsShared:
+            imports.append("import BagbutikCore")
+        case .usersModels:
+            imports.append("import BagbutikCore")
+            imports.append("import BagbutikModelsShared")
+        case .core:
+            break
+        case .legacyModels, nil:
+            if packageName != .core {
+                imports.append("import Bagbutik_Core")
+                if schema.name.hasSuffix("Request") || schema.name.hasSuffix("Response") {
+                    imports.append("import Bagbutik_Models")
+                }
+            } else if schema.name.hasSuffix("LinkagesRequest") || schema.name.hasSuffix("LinkageRequest")
+                || schema.name.hasSuffix("LinkagesResponse") || schema.name.hasSuffix("LinkageResponse") {
+                imports.append("import Bagbutik_Core")
             }
-        } else if schema.name.hasSuffix("LinkagesRequest") || schema.name.hasSuffix("LinkageRequest")
-            || schema.name.hasSuffix("LinkagesResponse") || schema.name.hasSuffix("LinkageResponse") {
-            imports.append("import Bagbutik_Core")
         }
         let contents = """
         \(imports.sorted().joined(separator: "\n"))

--- a/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
+++ b/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
@@ -1,0 +1,55 @@
+import BagbutikDocsCollector
+import BagbutikSpecDecoder
+import Foundation
+
+/// The model module assignment used while the version 24 graph is migrated one product at a time.
+public struct RuntimeModulePlan: Sendable {
+    public enum ModelModule: String, Sendable {
+        case core
+        case modelsShared
+        case usersModels
+        case legacyModels
+    }
+
+    public let moduleBySchema: [String: ModelModule]
+
+    /// Creates the first version 24 vertical slice from schema ownership and actual references.
+    public init(usersSliceFrom graph: SchemaReferenceGraph, packageBySchema: [String: PackageName]) {
+        let coreSchemas = Set(packageBySchema.compactMap { entry -> String? in
+            guard entry.value == .core,
+                  !entry.key.hasSuffix("LinkageRequest"),
+                  !entry.key.hasSuffix("LinkagesRequest"),
+                  !entry.key.hasSuffix("LinkageResponse"),
+                  !entry.key.hasSuffix("LinkagesResponse") else { return nil }
+            return entry.key
+        })
+        let userSchemas = Set(packageBySchema.compactMap { $0.value == .users ? $0.key : nil })
+        let usersClosure = graph.closure(startingAt: userSchemas)
+        var sharedSchemas = usersClosure.subtracting(coreSchemas).subtracting(userSchemas)
+        var usersModelSchemas = usersClosure.intersection(userSchemas)
+
+        for component in graph.stronglyConnectedComponents() where component.schemas.contains(where: usersClosure.contains) {
+            let schemas = Set(component.schemas)
+            if !schemas.isDisjoint(with: sharedSchemas) {
+                sharedSchemas.formUnion(schemas.subtracting(coreSchemas))
+                usersModelSchemas.subtract(schemas)
+            }
+        }
+
+        moduleBySchema = graph.references.keys.reduce(into: [:]) { result, schema in
+            if coreSchemas.contains(schema) {
+                result[schema] = .core
+            } else if sharedSchemas.contains(schema) {
+                result[schema] = .modelsShared
+            } else if usersModelSchemas.contains(schema) {
+                result[schema] = .usersModels
+            } else {
+                result[schema] = .legacyModels
+            }
+        }
+    }
+
+    public subscript(schemaName: String) -> ModelModule {
+        moduleBySchema[schemaName, default: .legacyModels]
+    }
+}

--- a/Tools/Sources/BagbutikGenerator/SchemaReferenceGraph.swift
+++ b/Tools/Sources/BagbutikGenerator/SchemaReferenceGraph.swift
@@ -1,0 +1,182 @@
+import BagbutikSpecDecoder
+import Foundation
+
+/// The dependency graph formed by references between top level OpenAPI schemas.
+public struct SchemaReferenceGraph: Sendable {
+    /// A strongly connected group of schemas that must stay in the same Swift module.
+    public struct Component: Hashable, Sendable {
+        public let schemas: [String]
+
+        public init(schemas: [String]) {
+            self.schemas = schemas.sorted()
+        }
+    }
+
+    /// References keyed by the top level schema that declares them.
+    public let references: [String: Set<String>]
+
+    public init(schemas: [String: Schema]) {
+        let schemaNames = Set(schemas.keys)
+        references = schemas.reduce(into: [:]) { result, entry in
+            result[entry.key] = Self.references(in: entry.value, schemaNames: schemaNames)
+        }
+    }
+
+    /// Loads and normalizes an OpenAPI document before building its schema graph.
+    public init(specFileURL: URL) throws {
+        let data = try Data(contentsOf: specFileURL)
+        var spec = try JSONDecoder().decode(Spec.self, from: data)
+        try spec.applyManualPatches()
+        spec.flattenIdenticalSchemas()
+        self.init(schemas: spec.components.schemas)
+    }
+
+    /// Returns all known schemas reachable from the supplied roots, including roots present in the graph.
+    /// Root names that are not present in the graph are ignored.
+    public func closure(startingAt roots: some Sequence<String>) -> Set<String> {
+        var pending = Array(roots)
+        var result = Set<String>()
+        while let schema = pending.popLast() {
+            guard references[schema] != nil, result.insert(schema).inserted else { continue }
+            pending.append(contentsOf: references[schema, default: []])
+        }
+        return result
+    }
+
+    /// Returns strongly connected components in stable lexical order.
+    public func stronglyConnectedComponents() -> [Component] {
+        var nextIndex = 0
+        var indexes = [String: Int]()
+        var lowLinks = [String: Int]()
+        var stack = [String]()
+        var onStack = Set<String>()
+        var components = [Component]()
+
+        func visit(_ schema: String) {
+            indexes[schema] = nextIndex
+            lowLinks[schema] = nextIndex
+            nextIndex += 1
+            stack.append(schema)
+            onStack.insert(schema)
+
+            for dependency in references[schema, default: []].sorted() {
+                if indexes[dependency] == nil {
+                    visit(dependency)
+                    lowLinks[schema] = min(lowLinks[schema]!, lowLinks[dependency]!)
+                } else if onStack.contains(dependency) {
+                    lowLinks[schema] = min(lowLinks[schema]!, indexes[dependency]!)
+                }
+            }
+
+            guard lowLinks[schema] == indexes[schema] else { return }
+            var schemas = [String]()
+            while let member = stack.popLast() {
+                onStack.remove(member)
+                schemas.append(member)
+                if member == schema { break }
+            }
+            components.append(Component(schemas: schemas))
+        }
+
+        for schema in references.keys.sorted() where indexes[schema] == nil {
+            visit(schema)
+        }
+        return components.sorted { $0.schemas[0] < $1.schemas[0] }
+    }
+
+    /// Returns the acyclic dependency graph produced by collapsing strongly connected schemas.
+    public func collapsedDependencies() -> [Component: Set<Component>] {
+        let components = stronglyConnectedComponents()
+        let componentBySchema = components.reduce(into: [String: Component]()) { result, component in
+            for schema in component.schemas {
+                result[schema] = component
+            }
+        }
+        return components.reduce(into: [Component: Set<Component>]()) { result, component in
+            result[component] = component.schemas.reduce(into: Set<Component>()) { dependencies, schema in
+                for dependency in references[schema, default: []] {
+                    guard let dependencyComponent = componentBySchema[dependency], dependencyComponent != component else { continue }
+                    dependencies.insert(dependencyComponent)
+                }
+            }
+        }
+    }
+
+    /// Returns a dependency first ordering of the collapsed graph.
+    public func topologicallySortedComponents() -> [Component] {
+        let collapsed = collapsedDependencies()
+        var visited = Set<Component>()
+        var result = [Component]()
+
+        func visit(_ component: Component) {
+            guard visited.insert(component).inserted else { return }
+            for dependency in collapsed[component, default: []].sorted(by: { $0.schemas[0] < $1.schemas[0] }) {
+                visit(dependency)
+            }
+            result.append(component)
+        }
+
+        for component in collapsed.keys.sorted(by: { $0.schemas[0] < $1.schemas[0] }) {
+            visit(component)
+        }
+        return result
+    }
+
+    private static func references(in schema: Schema, schemaNames: Set<String>) -> Set<String> {
+        switch schema {
+        case .object(let object): references(in: object, schemaNames: schemaNames)
+        case .enum, .binary, .plainText: []
+        }
+    }
+
+    private static func references(in object: ObjectSchema, schemaNames: Set<String>) -> Set<String> {
+        object.properties.values.reduce(into: Set<String>()) { result, property in
+            result.formUnion(references(in: property.type, schemaNames: schemaNames))
+        }
+    }
+
+    private static func references(in type: PropertyType, schemaNames: Set<String>) -> Set<String> {
+        switch type {
+        case .schemaRef(let name), .arrayOfSchemaRef(let name):
+            normalizedReference(name, schemaNames: schemaNames).map { [$0] } ?? []
+        case .schema(let object), .arrayOfSubSchema(let object):
+            references(in: object, schemaNames: schemaNames)
+        case .oneOf(_, let oneOf), .arrayOfOneOf(_, let oneOf):
+            references(in: oneOf, schemaNames: schemaNames)
+        case .dictionary(let value):
+            references(in: value, schemaNames: schemaNames)
+        case .simple, .constant, .enumSchema, .arrayOfEnumSchema, .arrayOfSimple:
+            []
+        }
+    }
+
+    private static func references(in oneOf: OneOfSchema, schemaNames: Set<String>) -> Set<String> {
+        var result = oneOf.options.reduce(into: Set<String>()) { result, option in
+            switch option {
+            case .schemaRef(let name):
+                if let reference = normalizedReference(name, schemaNames: schemaNames) {
+                    result.insert(reference)
+                }
+            case .objectSchema(let object):
+                result.formUnion(references(in: object, schemaNames: schemaNames))
+            case .simple:
+                break
+            }
+        }
+        if let discriminator = oneOf.discriminator {
+            for mapping in discriminator.mapping.values {
+                if let reference = normalizedReference(mapping, schemaNames: schemaNames) {
+                    result.insert(reference)
+                }
+            }
+        }
+        return result
+    }
+
+    private static func normalizedReference(_ reference: String, schemaNames: Set<String>) -> String? {
+        let unqualified = reference.split(separator: "/").last.map(String.init) ?? reference
+        if schemaNames.contains(unqualified) { return unqualified }
+        let topLevel = unqualified.split(separator: ".").first.map(String.init) ?? unqualified
+        return schemaNames.contains(topLevel) ? topLevel : nil
+    }
+}

--- a/Tools/Tests/BagbutikGeneratorTests/GeneratorTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/GeneratorTests.swift
@@ -67,7 +67,9 @@ final class GeneratorTests: XCTestCase {
             "/Users/steve/output/Bagbutik-Webhooks",
             "/Users/steve/output/Bagbutik-Models/Webhooks",
             "/Users/steve/output/Bagbutik-XcodeCloud",
-            "/Users/steve/output/Bagbutik-Models/XcodeCloud"
+            "/Users/steve/output/Bagbutik-Models/XcodeCloud",
+            "/Users/steve/output/BagbutikModelsShared",
+            "/Users/steve/output/BagbutikUsersModels"
         ])
         XCTAssertEqual(Set(fileManager.directoriesCreated).sorted(), [
             "/Users/steve/output/Bagbutik-AppStore",
@@ -83,9 +85,10 @@ final class GeneratorTests: XCTestCase {
             "/Users/steve/output/Bagbutik-Users",
             "/Users/steve/output/Bagbutik-Users/Endpoints/Users",
             "/Users/steve/output/Bagbutik-Users/Endpoints/Users/Relationships",
-            "/Users/steve/output/Bagbutik-Users/Models",
             "/Users/steve/output/Bagbutik-Webhooks",
-            "/Users/steve/output/Bagbutik-XcodeCloud"
+            "/Users/steve/output/Bagbutik-XcodeCloud",
+            "/Users/steve/output/BagbutikModelsShared",
+            "/Users/steve/output/BagbutikUsersModels"
         ])
         XCTAssertEqual(fileManager.filesCreated.map(\.name).sorted(), [
             "BuildAppLinkageResponse.swift",
@@ -114,6 +117,20 @@ final class GeneratorTests: XCTestCase {
             "⚡️ Generating model UsersResponse...",
         ])
         XCTAssertEqual(lastLogLine, "🎉 Finished generating 2 endpoints and 6 models! 🎉")
+        let usersResponse = String(
+            decoding: fileManager.filesCreated.first { $0.name == "UsersResponse.swift" }!.data,
+            as: UTF8.self
+        )
+        XCTAssertTrue(usersResponse.contains("import BagbutikCore"))
+        XCTAssertTrue(usersResponse.contains("import BagbutikModelsShared"))
+        XCTAssertFalse(usersResponse.contains("import Bagbutik_Models"))
+        let listUsers = String(
+            decoding: fileManager.filesCreated.first { $0.name == "ListUsersV1.swift" }!.data,
+            as: UTF8.self
+        )
+        XCTAssertTrue(listUsers.contains("import BagbutikCore"))
+        XCTAssertFalse(listUsers.contains("import Bagbutik_Core"))
+        XCTAssertTrue(listUsers.contains("import BagbutikUsersModels"))
     }
 
     func testInvalidSpecFileURL() async throws {
@@ -209,7 +226,7 @@ final class GeneratorTests: XCTestCase {
         // When
         await XCTAssertAsyncThrowsError(try await generator.generateAll(specFileURL: validSpecFileURL, outputDirURL: validOutputDirURL, documentationDirURL: validDocumentationDirURL)) {
             // Then
-            XCTAssertEqual($0 as? GeneratorError, .couldNotCreateFile("/Users/steve/output/Bagbutik-Users/Models/UsersResponse.swift"))
+            XCTAssertEqual($0 as? GeneratorError, .couldNotCreateFile("/Users/steve/output/BagbutikUsersModels/UsersResponse.swift"))
         }
     }
     
@@ -261,7 +278,7 @@ final class GeneratorTests: XCTestCase {
         try await generator.generateAll(specFileURL: validSpecFileURL, outputDirURL: validOutputDirURL, documentationDirURL: validDocumentationDirURL)
         // Then
         XCTAssertEqual(fileManager.filesCreated.map(\.name), ["UsersResponse.swift"])
-        XCTAssertEqual(fileManager.directoriesCreated.filter { $0.hasSuffix("/Bagbutik-Users/Models") }.count, 1)
+        XCTAssertTrue(fileManager.directoriesCreated.contains("/Users/steve/output/BagbutikUsersModels"))
     }
 
     func testInferPackageNameForOperationWithoutDocumentation() async throws {
@@ -310,7 +327,7 @@ final class GeneratorTests: XCTestCase {
         try await generator.generateAll(specFileURL: validSpecFileURL, outputDirURL: validOutputDirURL, documentationDirURL: validDocumentationDirURL)
 
         XCTAssertEqual(fileManager.filesCreated.map(\.name), ["User.swift"])
-        XCTAssertEqual(fileManager.directoriesCreated.filter { $0.hasSuffix("/Bagbutik-Models/Users") }.count, 1)
+        XCTAssertTrue(fileManager.directoriesCreated.contains("/Users/steve/output/BagbutikUsersModels"))
     }
 
     func testGenerateAllDoesNotRemoveMissingChildren() async throws {

--- a/Tools/Tests/BagbutikGeneratorTests/RuntimeModulePlanTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/RuntimeModulePlanTests.swift
@@ -1,0 +1,58 @@
+@testable import BagbutikDocsCollector
+@testable import BagbutikGenerator
+@testable import BagbutikSpecDecoder
+import XCTest
+
+final class RuntimeModulePlanTests: XCTestCase {
+    func testUsersClosureIsPlacedWithoutPullingInUnrelatedModels() {
+        let schemas: [String: Schema] = [
+            "CoreLinks": .object(.init(name: "CoreLinks", url: "")),
+            "App": .object(.init(name: "App", url: "", properties: [
+                "links": .init(type: .schemaRef("CoreLinks")),
+                "version": .init(type: .schemaRef("SubscriptionStatusUrlVersion")),
+            ])),
+            "SubscriptionStatusUrlVersion": .enum(.init(name: "SubscriptionStatusUrlVersion", type: "String", caseValues: ["V1"])),
+            "User": .object(.init(name: "User", url: "", properties: [
+                "app": .init(type: .schemaRef("App"))
+            ])),
+            "UsersResponse": .object(.init(name: "UsersResponse", url: "", properties: [
+                "data": .init(type: .arrayOfSchemaRef("User"))
+            ])),
+            "Build": .object(.init(name: "Build", url: "")),
+        ]
+        let packages: [String: PackageName] = [
+            "CoreLinks": .core,
+            "App": .appStore,
+            "SubscriptionStatusUrlVersion": .appStore,
+            "User": .users,
+            "UsersResponse": .users,
+            "Build": .appStore,
+        ]
+
+        let plan = RuntimeModulePlan(usersSliceFrom: .init(schemas: schemas), packageBySchema: packages)
+
+        XCTAssertEqual(plan["CoreLinks"], .core)
+        XCTAssertEqual(plan["App"], .modelsShared)
+        XCTAssertEqual(plan["SubscriptionStatusUrlVersion"], .modelsShared)
+        XCTAssertEqual(plan["User"], .usersModels)
+        XCTAssertEqual(plan["UsersResponse"], .usersModels)
+        XCTAssertEqual(plan["Build"], .legacyModels)
+    }
+
+    func testCrossDomainCycleIsKeptInOneSharedModule() {
+        let schemas: [String: Schema] = [
+            "User": .object(.init(name: "User", url: "", properties: [
+                "app": .init(type: .schemaRef("App"))
+            ])),
+            "App": .object(.init(name: "App", url: "", properties: [
+                "user": .init(type: .schemaRef("User"))
+            ])),
+        ]
+        let packages: [String: PackageName] = ["User": .users, "App": .appStore]
+
+        let plan = RuntimeModulePlan(usersSliceFrom: .init(schemas: schemas), packageBySchema: packages)
+
+        XCTAssertEqual(plan["User"], .modelsShared)
+        XCTAssertEqual(plan["App"], .modelsShared)
+    }
+}

--- a/Tools/Tests/BagbutikGeneratorTests/SchemaReferenceGraphTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/SchemaReferenceGraphTests.swift
@@ -1,0 +1,73 @@
+@testable import BagbutikGenerator
+@testable import BagbutikSpecDecoder
+import XCTest
+
+final class SchemaReferenceGraphTests: XCTestCase {
+    func testClosureIncludesReferencesFromEverySupportedContainer() throws {
+        let nested = ObjectSchema(
+            name: "Nested",
+            url: "",
+            properties: ["value": .init(type: .schemaRef("Leaf"))]
+        )
+        let choice = OneOfSchema(
+            options: [.schemaRef("Choice"), .objectSchema(nested)],
+            discriminator: .init(propertyName: "type", mapping: ["mapped": "#/components/schemas/Mapped"])
+        )
+        let root = ObjectSchema(
+            name: "Root",
+            url: "",
+            properties: [
+                "array": .init(type: .arrayOfSchemaRef("ArrayItem")),
+                "dictionary": .init(type: .dictionary(.schemaRef("DictionaryValue"))),
+                "nested": .init(type: .schema(nested)),
+                "choice": .init(type: .oneOf(name: "ChoiceValue", schema: choice)),
+                "qualified": .init(type: .schemaRef("Qualified.Attributes.State")),
+            ]
+        )
+        let names = ["Root", "ArrayItem", "DictionaryValue", "Leaf", "Choice", "Mapped", "Qualified"]
+        let schemas: [String: Schema] = Dictionary(uniqueKeysWithValues: names.map { name in
+            (name, name == "Root" ? Schema.object(root) : Schema.object(.init(name: name, url: "")))
+        })
+
+        let closure = SchemaReferenceGraph(schemas: schemas).closure(startingAt: ["Root"])
+
+        XCTAssertEqual(closure, Set(names))
+    }
+
+    func testClosureIgnoresUnknownRoots() {
+        let schemas: [String: Schema] = [
+            "Known": .object(.init(name: "Known", url: "")),
+        ]
+
+        let closure = SchemaReferenceGraph(schemas: schemas).closure(startingAt: ["Known", "Missing"])
+
+        XCTAssertEqual(closure, ["Known"])
+    }
+
+    func testCyclesBecomeOneComponentAndCollapsedGraphIsDependencyFirst() {
+        let schemas: [String: Schema] = [
+            "EndpointResponse": .object(.init(name: "EndpointResponse", url: "", properties: [
+                "data": .init(type: .schemaRef("User"))
+            ])),
+            "User": .object(.init(name: "User", url: "", properties: [
+                "relationships": .init(type: .schemaRef("VisibleApps"))
+            ])),
+            "VisibleApps": .object(.init(name: "VisibleApps", url: "", properties: [
+                "owner": .init(type: .schemaRef("User")),
+                "app": .init(type: .schemaRef("App")),
+            ])),
+            "App": .object(.init(name: "App", url: "")),
+        ]
+        let graph = SchemaReferenceGraph(schemas: schemas)
+
+        let components = graph.stronglyConnectedComponents()
+        XCTAssertTrue(components.contains(.init(schemas: ["User", "VisibleApps"])))
+
+        let ordered = graph.topologicallySortedComponents()
+        let appIndex = ordered.firstIndex(of: .init(schemas: ["App"]))!
+        let cycleIndex = ordered.firstIndex(of: .init(schemas: ["User", "VisibleApps"]))!
+        let responseIndex = ordered.firstIndex(of: .init(schemas: ["EndpointResponse"]))!
+        XCTAssertLessThan(appIndex, cycleIndex)
+        XCTAssertLessThan(cycleIndex, responseIndex)
+    }
+}

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -2,304 +2,530 @@
 
 set -euo pipefail
 
-IOS_DEVICE_SDK="iphoneos"
-IOS_SIMULATOR_SDK="iphonesimulator"
-MACOS_SDK="macosx"
-TVOS_DEVICE_SDK="appletvos"
-TVOS_SIMULATOR_SDK="appletvsimulator"
-WATCHOS_DEVICE_SDK="watchos"
-WATCHOS_SIMULATOR_SDK="watchsimulator"
-VISIONOS_DEVICE_SDK="xros"
-VISIONOS_SIMULATOR_SDK="xrsimulator"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/xcframework"
+DIST_DIR="$ROOT_DIR/output"
+INTEGRATION_DIR="$BUILD_DIR/integration"
+CONFIGURATION="release"
+BUILD_TARGET="BagbutikUsers"
 
-LIBRARY="Bagbutik"
+MODULES=(
+  "BagbutikCore"
+  "BagbutikModelsShared"
+  "BagbutikUsersModels"
+  "BagbutikUsers"
+)
 
 SDKS=(
-  "$IOS_DEVICE_SDK"
-  "$IOS_SIMULATOR_SDK"
-  "$MACOS_SDK"
-  "$TVOS_DEVICE_SDK"
-  "$TVOS_SIMULATOR_SDK"
-  "$WATCHOS_DEVICE_SDK"
-  "$WATCHOS_SIMULATOR_SDK"
-  "$VISIONOS_DEVICE_SDK"
-  "$VISIONOS_SIMULATOR_SDK"
+  "iphoneos"
+  "iphonesimulator"
+  "macosx"
+  "appletvos"
+  "appletvsimulator"
+  "watchos"
+  "watchsimulator"
+  "xros"
+  "xrsimulator"
 )
 
 if [ -n "${BAGBUTIK_SDKS:-}" ]; then
   IFS=',' read -r -a SDKS <<< "$BAGBUTIK_SDKS"
 fi
-CONFIGURATION="Release"
 
-codesign_framework() {
-  local framework_path=$1
-
-  echo "Codesigning framework: $framework_path"
-  codesign --force --sign "-" --timestamp=none "$framework_path" || exit 22
-  codesign --verify --strict "$framework_path" || exit 23
+sdk_triples() {
+  case "$1" in
+    iphoneos)
+      echo "arm64-apple-ios15.0"
+      ;;
+    iphonesimulator)
+      echo "arm64-apple-ios15.0-simulator"
+      echo "x86_64-apple-ios15.0-simulator"
+      ;;
+    macosx)
+      echo "arm64-apple-macosx12.0"
+      echo "x86_64-apple-macosx12.0"
+      ;;
+    appletvos)
+      echo "arm64-apple-tvos15.0"
+      ;;
+    appletvsimulator)
+      echo "arm64-apple-tvos15.0-simulator"
+      echo "x86_64-apple-tvos15.0-simulator"
+      ;;
+    watchos)
+      echo "arm64_32-apple-watchos9.0"
+      echo "arm64-apple-watchos9.0"
+      ;;
+    watchsimulator)
+      echo "arm64-apple-watchos9.0-simulator"
+      echo "x86_64-apple-watchos9.0-simulator"
+      ;;
+    xros)
+      echo "arm64-apple-xros1.0"
+      ;;
+    xrsimulator)
+      echo "arm64-apple-xros1.0-simulator"
+      ;;
+    *)
+      echo "Unknown SDK: $1" >&2
+      exit 11
+      ;;
+  esac
 }
 
-ROOT_DIR="$(pwd)"
-BUILD_DIR="$ROOT_DIR/build"
-DIST_DIR="$ROOT_DIR/output"
-MONOLITHIC_PACKAGE_DIR="$BUILD_DIR/MonolithicPackage"
-
-discover_libraries() {
-  LIBRARIES=()
-  while IFS= read -r library; do
-    LIBRARIES+=("$library")
-  done < <(
-    find "$ROOT_DIR/Sources" -mindepth 1 -maxdepth 1 -type d -name 'Bagbutik-*' -print \
-      | sed 's#.*/##' \
-      | sort
-  )
-
-  if [ ${#LIBRARIES[@]} -eq 0 ]; then
-    echo "No source libraries found in $ROOT_DIR/Sources matching Bagbutik-*"
-    exit 17
+swiftpm_triple_directory() {
+  if [[ "$1" == *-apple-xros* ]]; then
+    echo "$1"
+    return
   fi
 
-  echo "Discovered libraries:"
-  for library in "${LIBRARIES[@]}"; do
-    echo "- $library"
-  done
+  echo "$1" | sed -E 's/(macosx|ios|tvos|watchos|xros)[0-9]+(\.[0-9]+)*/\1/'
 }
 
-sdk_is_available() {
-  local sdk=$1
-  xcrun --sdk "$sdk" --show-sdk-path >/dev/null 2>&1
+swift_module_triple() {
+  echo "$1" \
+    | sed -E 's/(macosx|ios|tvos|watchos|xros)[0-9]+(\.[0-9]+)*/\1/' \
+    | sed 's/apple-macosx/apple-macos/'
 }
 
-require_all_sdks() {
-  missing_sdks=()
+sdk_path() {
+  xcrun --sdk "$1" --show-sdk-path
+}
 
-  for sdk in "${SDKS[@]}"; do
-    if ! sdk_is_available "$sdk"; then
-      missing_sdks+=("$sdk (SDK not installed)")
+require_tools_and_sdks() {
+  local tool
+  local sdk
+  local missing=()
+
+  for tool in swift xcodebuild xcrun zip; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      missing+=("$tool")
     fi
   done
 
-  if [ ${#missing_sdks[@]} -gt 0 ]; then
-    echo "Missing required SDKs: ${missing_sdks[*]}"
-    echo "Install the missing platforms in Xcode before building release artifacts."
-    exit 16
+  for sdk in "${SDKS[@]}"; do
+    if ! xcrun --sdk "$sdk" --show-sdk-path >/dev/null 2>&1; then
+      missing+=("$sdk SDK")
+    fi
+  done
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "Missing required build tools or SDKs: ${missing[*]}" >&2
+    exit 12
   fi
 }
 
-prepare_monolithic_package() {
-  echo "*** Prepare release package ***"
+prepare_directories() {
+  if [ "$BUILD_DIR" != "$ROOT_DIR/build/xcframework" ] || [ "$DIST_DIR" != "$ROOT_DIR/output" ]; then
+    echo "Refusing to clean unexpected build paths." >&2
+    exit 13
+  fi
 
-  rm -rf "$MONOLITHIC_PACKAGE_DIR"
-  mkdir -p "$MONOLITHIC_PACKAGE_DIR/Sources/$LIBRARY"
+  if [ "${BAGBUTIK_KEEP_BUILD:-false}" != "true" ]; then
+    rm -rf "$BUILD_DIR"
+  else
+    rm -rf "$BUILD_DIR/thin"
+    rm -rf "$BUILD_DIR/libraries"
+    rm -rf "$INTEGRATION_DIR"
+  fi
+  rm -rf "$DIST_DIR"
+  mkdir -p "$BUILD_DIR" "$DIST_DIR"
+}
 
-  cat > "$MONOLITHIC_PACKAGE_DIR/Package.swift" <<PACKAGE_EOF
+build_triple() {
+  local sdk=$1
+  local triple=$2
+  local sdk_root
+  local scratch_path="$BUILD_DIR/swiftpm/$triple"
+
+  sdk_root="$(sdk_path "$sdk")"
+
+  if [ "$sdk" = "xros" ] || [ "$sdk" = "xrsimulator" ]; then
+    build_visionos_triple "$triple" "$sdk_root"
+    return
+  fi
+
+  echo "Building $BUILD_TARGET for $triple"
+  swift build \
+    --package-path "$ROOT_DIR" \
+    --scratch-path "$scratch_path" \
+    --triple "$triple" \
+    --sdk "$sdk_root" \
+    --target "$BUILD_TARGET" \
+    --configuration "$CONFIGURATION" \
+    -Xswiftc -enable-library-evolution \
+    -Xswiftc -emit-module-interface
+}
+
+module_source_directory() {
+  case "$1" in
+    BagbutikCore)
+      echo "$ROOT_DIR/Sources/Bagbutik-Core"
+      ;;
+    BagbutikModelsShared)
+      echo "$ROOT_DIR/Sources/BagbutikModelsShared"
+      ;;
+    BagbutikUsersModels)
+      echo "$ROOT_DIR/Sources/BagbutikUsersModels"
+      ;;
+    BagbutikUsers)
+      echo "$ROOT_DIR/Sources/Bagbutik-Users"
+      ;;
+    *)
+      echo "No source directory mapping for $1" >&2
+      exit 18
+      ;;
+  esac
+}
+
+build_visionos_triple() {
+  local triple=$1
+  local sdk_root=$2
+  local product_directory="$BUILD_DIR/direct/$triple"
+  local modules_directory="$product_directory/Modules"
+  local module
+  local source_directory
+  local module_build_directory
+  local sources=()
+
+  echo "Building $BUILD_TARGET directly for $triple"
+  mkdir -p "$modules_directory" "$product_directory/ModuleCache"
+
+  for module in "${MODULES[@]}"; do
+    source_directory="$(module_source_directory "$module")"
+    module_build_directory="$product_directory/$module.build"
+    sources=()
+
+    while IFS= read -r source; do
+      sources+=("$source")
+    done < <(find "$source_directory" -type f -name '*.swift' -print | sort)
+
+    if [ ${#sources[@]} -eq 0 ]; then
+      echo "No Swift sources found for $module at $source_directory" >&2
+      exit 19
+    fi
+
+    mkdir -p "$module_build_directory"
+    swiftc "${sources[@]}" \
+      -parse-as-library \
+      -O \
+      -whole-module-optimization \
+      -swift-version 6 \
+      -target "$triple" \
+      -sdk "$sdk_root" \
+      -module-cache-path "$product_directory/ModuleCache" \
+      -I "$modules_directory" \
+      -module-name "$module" \
+      -enable-library-evolution \
+      -emit-module \
+      -emit-module-path "$modules_directory/$module.swiftmodule" \
+      -emit-module-interface-path "$module_build_directory/$module.swiftinterface" \
+      -emit-object \
+      -o "$module_build_directory/$module.o"
+  done
+}
+
+archive_thin_module() {
+  local sdk=$1
+  local triple=$2
+  local module=$3
+  local triple_directory
+  local product_directory
+  local module_build_directory
+  local thin_directory="$BUILD_DIR/thin/$triple"
+  local objects=()
+
+  if [ "$sdk" = "xros" ] || [ "$sdk" = "xrsimulator" ]; then
+    product_directory="$BUILD_DIR/direct/$triple"
+  else
+    triple_directory="$(swiftpm_triple_directory "$triple")"
+    product_directory="$BUILD_DIR/swiftpm/$triple/$triple_directory/$CONFIGURATION"
+  fi
+  module_build_directory="$product_directory/$module.build"
+
+  if [ ! -f "$module_build_directory/$module.swiftinterface" ]; then
+    echo "Missing public module interface for $module at $module_build_directory" >&2
+    exit 14
+  fi
+
+  while IFS= read -r object; do
+    objects+=("$object")
+  done < <(find "$module_build_directory" -maxdepth 1 -type f -name '*.o' -print | sort)
+
+  if [ ${#objects[@]} -eq 0 ]; then
+    echo "No object files found for $module at $module_build_directory" >&2
+    exit 15
+  fi
+
+  mkdir -p "$thin_directory"
+  xcrun libtool -static -o "$thin_directory/lib$module.a" "${objects[@]}"
+
+  local interface_directory="$BUILD_DIR/libraries/$sdk/$module/Headers/$module.swiftmodule"
+  mkdir -p "$interface_directory"
+  cp "$module_build_directory/$module.swiftinterface" "$interface_directory/$(swift_module_triple "$triple").swiftinterface"
+}
+
+combine_sdk_module() {
+  local sdk=$1
+  local module=$2
+  local libraries=()
+  local triple
+  local output_directory="$BUILD_DIR/libraries/$sdk/$module"
+
+  while IFS= read -r triple; do
+    libraries+=("$BUILD_DIR/thin/$triple/lib$module.a")
+  done < <(sdk_triples "$sdk")
+
+  mkdir -p "$output_directory"
+  xcrun lipo -create "${libraries[@]}" -output "$output_directory/lib$module.a"
+  xcrun strip -S "$output_directory/lib$module.a"
+}
+
+create_module_xcframework() {
+  local module=$1
+  local args=()
+  local sdk
+
+  for sdk in "${SDKS[@]}"; do
+    args+=(
+      -library "$BUILD_DIR/libraries/$sdk/$module/lib$module.a"
+      -headers "$BUILD_DIR/libraries/$sdk/$module/Headers"
+    )
+  done
+
+  echo "Creating $module.xcframework"
+  xcodebuild -create-xcframework "${args[@]}" -output "$DIST_DIR/$module.xcframework"
+
+  if find "$DIST_DIR/$module.xcframework" -type f -name '*.swiftinterface' -print -quit | grep -q .; then
+    return
+  fi
+
+  echo "No public Swift module interfaces found in $module.xcframework" >&2
+  exit 16
+}
+
+zip_module_xcframework() {
+  local module=$1
+
+  if [ "${BAGBUTIK_SKIP_ZIP:-false}" = "true" ]; then
+    return
+  fi
+
+  (
+    cd "$DIST_DIR"
+    zip -qry "$module.xcframework.zip" "$module.xcframework"
+  )
+}
+
+prepare_binary_integration_fixture() {
+  mkdir -p "$INTEGRATION_DIR/BagbutikBinaryPackage/Artifacts"
+  mkdir -p "$INTEGRATION_DIR/BagbutikUsersBinaryClient/Sources/BagbutikUsersBinaryClient"
+
+  cat > "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift" <<'PACKAGE_EOF'
 // swift-tools-version:6.0
 
 import PackageDescription
 
 let package = Package(
-    name: "$LIBRARY",
+    name: "Bagbutik",
     platforms: [
         .macOS(.v12),
         .iOS(.v15),
         .tvOS(.v15),
         .watchOS(.v9),
-        .visionOS(.v1)
+        .visionOS(.v1),
     ],
     products: [
         .library(
-            name: "$LIBRARY",
-            type: .dynamic,
-            targets: ["$LIBRARY"]
-        )
+            name: "BagbutikUsers",
+            targets: [
+                "BagbutikCore",
+                "BagbutikModelsShared",
+                "BagbutikUsersModels",
+                "BagbutikUsers",
+            ]
+        ),
     ],
     targets: [
-        .target(name: "$LIBRARY")
-    ],
-    swiftLanguageModes: [.v5, .v6]
+        .binaryTarget(name: "BagbutikCore", path: "Artifacts/BagbutikCore.xcframework"),
+        .binaryTarget(name: "BagbutikModelsShared", path: "Artifacts/BagbutikModelsShared.xcframework"),
+        .binaryTarget(name: "BagbutikUsersModels", path: "Artifacts/BagbutikUsersModels.xcframework"),
+        .binaryTarget(name: "BagbutikUsers", path: "Artifacts/BagbutikUsers.xcframework"),
+    ]
 )
 PACKAGE_EOF
 
-  for library in "${LIBRARIES[@]}"; do
-    source_path="$ROOT_DIR/Sources/$library"
-    if [ ! -d "$source_path" ]; then
-      echo "Missing source directory: $source_path"
-      exit 18
-    fi
+  cat > "$INTEGRATION_DIR/BagbutikUsersBinaryClient/Package.swift" <<'PACKAGE_EOF'
+// swift-tools-version:6.0
 
-    target_path="$MONOLITHIC_PACKAGE_DIR/Sources/$LIBRARY/$library"
-    mkdir -p "$target_path"
-    cp -R "$source_path"/. "$target_path"
+import PackageDescription
+
+let package = Package(
+    name: "BagbutikUsersBinaryClient",
+    platforms: [
+        .macOS(.v12),
+        .iOS(.v15),
+        .tvOS(.v15),
+        .watchOS(.v9),
+        .visionOS(.v1),
+    ],
+    dependencies: [
+        .package(name: "Bagbutik", path: "../BagbutikBinaryPackage"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "BagbutikUsersBinaryClient",
+            dependencies: [
+                .product(name: "BagbutikUsers", package: "Bagbutik"),
+            ]
+        ),
+    ]
+)
+PACKAGE_EOF
+
+  cat > "$INTEGRATION_DIR/BagbutikUsersBinaryClient/Sources/BagbutikUsersBinaryClient/main.swift" <<'SOURCE_EOF'
+import BagbutikCore
+import BagbutikModelsShared
+import BagbutikUsers
+import BagbutikUsersModels
+
+let request = Request<UsersResponse, ErrorResponse>.listUsersV1(
+    filters: [.roles([.admin])],
+    includes: [.visibleApps],
+    limits: [.limit(20)]
+)
+
+print(request.path)
+SOURCE_EOF
+
+  local module
+  for module in "${MODULES[@]}"; do
+    cp -R "$DIST_DIR/$module.xcframework" "$INTEGRATION_DIR/BagbutikBinaryPackage/Artifacts/"
   done
-
-  # In the monolithic release target all Bagbutik types live in the same module,
-  # so inter-module imports must be removed.
-  while IFS= read -r -d '' file; do
-    perl -0pi -e 's/^import Bagbutik_[A-Za-z0-9_]+\n//mg' "$file"
-  done < <(find "$MONOLITHIC_PACKAGE_DIR/Sources/$LIBRARY" -name '*.swift' -type f -print0)
 }
 
-build_framework() {
-  local scheme=$1
-  local sdk=$2
-  local dest=""
-  local -a build_settings=(
-    "SKIP_INSTALL=NO"
-    "BUILD_LIBRARY_FOR_DISTRIBUTION=YES"
+verify_binary_integration() {
+  local sdk
+  local triple
+  local sdk_root
+
+  if [ "${BAGBUTIK_SKIP_VERIFY:-false}" = "true" ]; then
+    return
+  fi
+
+  prepare_binary_integration_fixture
+
+  for sdk in "${SDKS[@]}"; do
+    sdk_root="$(sdk_path "$sdk")"
+    while IFS= read -r triple; do
+      if [ "$sdk" = "xros" ] || [ "$sdk" = "xrsimulator" ]; then
+        verify_visionos_binary_integration "$sdk" "$triple" "$sdk_root"
+        continue
+      fi
+
+      echo "Verifying binary package consumer for $triple"
+      swift build \
+        --package-path "$INTEGRATION_DIR/BagbutikUsersBinaryClient" \
+        --scratch-path "$INTEGRATION_DIR/build/$triple" \
+        --triple "$triple" \
+        --sdk "$sdk_root" \
+        --configuration "$CONFIGURATION"
+    done < <(sdk_triples "$sdk")
+  done
+}
+
+verify_visionos_binary_integration() {
+  local sdk=$1
+  local triple=$2
+  local sdk_root=$3
+  local library_identifier
+  local module
+  local import_arguments=()
+  local libraries=()
+  local output_directory="$INTEGRATION_DIR/build/$triple"
+
+  if [ "$sdk" = "xros" ]; then
+    library_identifier="xros-arm64"
+  else
+    library_identifier="xros-arm64-simulator"
+  fi
+
+  for module in "${MODULES[@]}"; do
+    import_arguments+=(
+      -I "$DIST_DIR/$module.xcframework/$library_identifier/Headers"
+    )
+  done
+
+  libraries+=(
+    "$DIST_DIR/BagbutikUsers.xcframework/$library_identifier/libBagbutikUsers.a"
+    "$DIST_DIR/BagbutikUsersModels.xcframework/$library_identifier/libBagbutikUsersModels.a"
+    "$DIST_DIR/BagbutikModelsShared.xcframework/$library_identifier/libBagbutikModelsShared.a"
+    "$DIST_DIR/BagbutikCore.xcframework/$library_identifier/libBagbutikCore.a"
   )
 
-  if [ "$sdk" = "$IOS_DEVICE_SDK" ]; then
-    dest="generic/platform=iOS"
-  elif [ "$sdk" = "$IOS_SIMULATOR_SDK" ]; then
-    dest="generic/platform=iOS Simulator"
-  elif [ "$sdk" = "$MACOS_SDK" ]; then
-    dest="generic/platform=macOS"
-  elif [ "$sdk" = "$TVOS_DEVICE_SDK" ]; then
-    dest="generic/platform=tvOS"
-  elif [ "$sdk" = "$TVOS_SIMULATOR_SDK" ]; then
-    dest="generic/platform=tvOS Simulator"
-  elif [ "$sdk" = "$WATCHOS_DEVICE_SDK" ]; then
-    dest="generic/platform=watchOS"
-  elif [ "$sdk" = "$WATCHOS_SIMULATOR_SDK" ]; then
-    dest="generic/platform=watchOS Simulator"
-  elif [ "$sdk" = "$VISIONOS_DEVICE_SDK" ]; then
-    dest="generic/platform=visionOS"
-  elif [ "$sdk" = "$VISIONOS_SIMULATOR_SDK" ]; then
-    dest="generic/platform=visionOS Simulator"
-  else
-    echo "Unknown SDK $sdk"
-    exit 11
-  fi
-
-  echo "*** Build framework ***"
-  echo "Scheme: $scheme"
-  echo "Configuration: $CONFIGURATION"
-  echo "SDK: $sdk"
-  echo "Destination: $dest"
-  echo
-
-  (
-    cd "$MONOLITHIC_PACKAGE_DIR"
-    xcodebuild \
-      -scheme "$scheme" \
-      -configuration "$CONFIGURATION" \
-      -destination "$dest" \
-      -sdk "$sdk" \
-      -derivedDataPath "$BUILD_DIR" \
-      "${build_settings[@]}"
-  ) || exit 12
-
-  local configuration_folder=""
-  if [ "$sdk" = "$MACOS_SDK" ]; then
-    configuration_folder=$CONFIGURATION
-  else
-    configuration_folder="$CONFIGURATION-$sdk"
-  fi
-
-  local product_path="$BUILD_DIR/Build/Products/$configuration_folder"
-  local framework_path="$product_path/PackageFrameworks/$scheme.framework"
-  local modules_path="$framework_path/Modules"
-
-  if [ ! -d "$framework_path" ]; then
-    echo "Missing framework output at $framework_path"
-    exit 13
-  fi
-
-  if [ -d "$framework_path/Versions/Current" ]; then
-    # Versioned frameworks (macOS) store module metadata under Versions/Current.
-    modules_path="$framework_path/Versions/Current/Modules"
-    if [ ! -e "$framework_path/Modules" ] && [ ! -L "$framework_path/Modules" ]; then
-      ln -s "Versions/Current/Modules" "$framework_path/Modules"
-    fi
-  fi
-
-  mkdir -p "$modules_path"
-
-  local modulemap_source="$BUILD_DIR/Build/Intermediates.noindex/$scheme.build/$configuration_folder/$scheme.build/$scheme.modulemap"
-  if [ ! -f "$modulemap_source" ]; then
-    echo "Missing module map output at $modulemap_source"
-    exit 14
-  fi
-  cp -pv "$modulemap_source" "$modules_path" || exit 15
-
-  local header_source=""
-  header_source="$(find "$BUILD_DIR/Build/Intermediates.noindex/$scheme.build/$configuration_folder/$scheme.build/Objects-normal" -name "$scheme-Swift.h" -type f | head -n 1)"
-  if [ -z "$header_source" ]; then
-    echo "Missing generated Swift header for module $scheme"
-    exit 16
-  fi
-  cp -pv "$header_source" "$modules_path" || exit 17
-
-  local swiftmodule_source="$product_path/$scheme.swiftmodule"
-  if [ ! -d "$swiftmodule_source" ]; then
-    echo "Missing swiftmodule output at $swiftmodule_source"
-    exit 18
-  fi
-
-  mkdir -p "$modules_path/$scheme.swiftmodule"
-  cp -pv "$swiftmodule_source"/*.* "$modules_path/$scheme.swiftmodule/" || exit 19
-
-  codesign_framework "$framework_path"
+  echo "Verifying binary package modules directly for $triple"
+  mkdir -p "$output_directory/ModuleCache"
+  swiftc \
+    -O \
+    -target "$triple" \
+    -sdk "$sdk_root" \
+    -module-cache-path "$output_directory/ModuleCache" \
+    "${import_arguments[@]}" \
+    "$INTEGRATION_DIR/BagbutikUsersBinaryClient/Sources/BagbutikUsersBinaryClient/main.swift" \
+    "${libraries[@]}" \
+    -lz \
+    -Xlinker -dead_strip \
+    -o "$output_directory/BagbutikUsersBinaryClient"
 }
 
-create_xcframework() {
-  local scheme=$1
-  shift 1
+report_watch_sample_size() {
+  local arm64_32_binary="$INTEGRATION_DIR/build/arm64_32-apple-watchos9.0/arm64_32-apple-watchos/$CONFIGURATION/BagbutikUsersBinaryClient"
+  local arm64_binary="$INTEGRATION_DIR/build/arm64-apple-watchos9.0/arm64-apple-watchos/$CONFIGURATION/BagbutikUsersBinaryClient"
+  local universal_binary="$DIST_DIR/BagbutikUsersWatchSample"
 
-  echo "*** Create $scheme.xcframework ***"
-  echo "Scheme: $scheme"
-  echo "SDKs: $*"
-  echo
+  if [ ! -f "$arm64_32_binary" ] || [ ! -f "$arm64_binary" ]; then
+    return
+  fi
 
-  args=()
-  for sdk in "$@"; do
-    local configuration_folder=""
-    if [ "$sdk" = "$MACOS_SDK" ]; then
-      configuration_folder=$CONFIGURATION
-    else
-      configuration_folder="$CONFIGURATION-$sdk"
-    fi
+  xcrun lipo -create "$arm64_32_binary" "$arm64_binary" -output "$universal_binary"
+  xcrun strip -x "$universal_binary"
 
-    args+=(-framework "$BUILD_DIR/Build/Products/$configuration_folder/PackageFrameworks/$scheme.framework")
+  local size
+  size="$(stat -f '%z' "$universal_binary")"
+  echo "Stripped two architecture watch sample executable: $size bytes"
 
-    local symbol_path="$BUILD_DIR/Build/Products/$configuration_folder/$scheme.framework.dSYM"
-    if [ -d "$symbol_path" ]; then
-      args+=(-debug-symbols "$symbol_path")
-    fi
-  done
-
-  xcodebuild -create-xcframework "${args[@]}" -output "$DIST_DIR/$scheme.xcframework" || exit 21
+  if [ "$size" -gt 50000000 ]; then
+    echo "Watch sample executable exceeds the 50 MB release gate." >&2
+    exit 17
+  fi
 }
 
-echo
-echo "****** Build XCFramework ******"
-echo
+echo "Building static Bagbutik XCFrameworks"
+echo "Modules: ${MODULES[*]}"
+echo "SDKs: ${SDKS[*]}"
 
-rm -rf "$BUILD_DIR"
-rm -rf "$DIST_DIR"
-mkdir -p "$DIST_DIR"
-
-require_all_sdks
-discover_libraries
-prepare_monolithic_package
+require_tools_and_sdks
+prepare_directories
 
 for sdk in "${SDKS[@]}"; do
-  build_framework "$LIBRARY" "$sdk"
-  echo
+  while IFS= read -r triple; do
+    build_triple "$sdk" "$triple"
+    for module in "${MODULES[@]}"; do
+      archive_thin_module "$sdk" "$triple" "$module"
+    done
+  done < <(sdk_triples "$sdk")
+
+  for module in "${MODULES[@]}"; do
+    combine_sdk_module "$sdk" "$module"
+  done
 done
 
-create_xcframework "$LIBRARY" "${SDKS[@]}"
+for module in "${MODULES[@]}"; do
+  create_module_xcframework "$module"
+  zip_module_xcframework "$module"
+done
 
-while IFS= read -r -d '' framework_path; do
-  codesign_framework "$framework_path"
-done < <(find "$DIST_DIR/$LIBRARY.xcframework" -type d -name '*.framework' -print0)
+verify_binary_integration
+report_watch_sample_size
 
-pushd "$DIST_DIR" >/dev/null
-if [ "${BAGBUTIK_SKIP_ZIP:-false}" = "true" ]; then
-  echo "Skipping zip step because BAGBUTIK_SKIP_ZIP=true"
-else
-  zip -yr "$LIBRARY.xcframework.zip" "$LIBRARY.xcframework"
-fi
-popd >/dev/null
-
-echo "Finished building XCFramework archive in $DIST_DIR"
+echo "Finished building static XCFramework archives in $DIST_DIR"


### PR DESCRIPTION
## What changed

This adds the first complete domain slice for the version 24 package architecture:

* Adds internal schema dependency and cycle handling to source generation so model placement follows actual OpenAPI references.
* Adds clean `BagbutikCore`, `BagbutikModelsShared`, `BagbutikUsersModels`, and `BagbutikUsers` targets.
* Adds the `BagbutikUsers` product, which exposes those four targets as one selectable source package product.
* Adds a small `Bagbutik_Core` compatibility target that reexports `BagbutikCore` for API products that have not migrated yet.
* Routes the Users schema closure into the new targets while retaining legacy model exports for API areas that have not yet migrated.
* Removes the source umbrella product so consumers select only the API products they use.
* Replaces the monolithic dynamic framework build with four static XCFrameworks and temporary consumer verification created by the release script.
* Adds public behavior tests for the Users API.

This pull request targets the version 24 integration branch. The completed migration will reach `main` only after every API product and final consumer gate is complete.

## Target closure

The `BagbutikUsers` source product currently consists of 59 Swift files:

* `BagbutikCore`: 40 service, request, authentication, pagination, and foundation files.
* `BagbutikModelsShared`: 2 generated models shared across public API products.
* `BagbutikUsersModels`: 9 generated Users resource, request, response, and enum files.
* `BagbutikUsers`: 8 generated Users and User Invitations endpoint files.

The endpoint target depends on the Users models, shared models, and Core. The Users models depend on shared models and Core. Shared models depend only on Core.

The compatibility target is not part of the `BagbutikUsers` product and does not affect its source closure or binary artifacts.

## Why

Source consumers previously compiled a much larger generated graph than a Users only application needed. The monolithic dynamic XCFramework avoided recompilation, but carried the complete API surface into watch applications.

The new source product compiles only the Users closure. The static binary modules preserve precompiled distribution while allowing the final application link to remove unused code.

## Consumer impact

This is part of the breaking version 24 release:

* The migrated Users targets import `BagbutikCore`.
* Existing API targets continue importing `Bagbutik_Core` until their own migration slice.
* The Users product and module become `BagbutikUsers`.
* Binary distribution uses the same package and product names as source distribution, from a separate repository URL.
* The minimum watchOS version is 9 and watch device binaries contain `arm64_32` and `arm64`, with no `armv7k` slice.
* Xcode 16 or newer is required.

Legacy API products and their existing Core imports remain available while their generated model closures are migrated in later slices. The compatibility target will be removed after the final slice and before the completed version 24 integration branch reaches `main`.

## Validation

* Root package: 76 tests passed.
* Tools package: 216 tests passed.
* Generated Users output matched the checked in source closure.
* The source product built while selecting only `BagbutikUsers`.
* Temporary static binary consumers linked for iOS, macOS, tvOS, watchOS, and their simulators across supported architectures.
* visionOS device and simulator interfaces and links were verified directly because the current SwiftPM command line triple normalization does not select `xros` binary slices correctly.
* AppStoreConnectKit `ConnectAccounts` built against this branch from an isolated copy.
* AppDabCore built through the patched AppStoreConnectKit dependency from an isolated copy.
* Comparable clean build median improved from 25.96 seconds to 8.23 seconds, about 68 percent faster.
* Comparable zero change build median improved from 3.07 seconds to 1.21 seconds, about 61 percent faster.
* The stripped two architecture watch sample executable is 2,400,616 bytes, below the 50 MB release gate.
