### PR TITLE
Prune generated model imports

### DIFF
--- a/Sources/BagbutikAppStoreModels/AccessibilityDeclaration.swift
+++ b/Sources/BagbutikAppStoreModels/AccessibilityDeclaration.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AccessibilityDeclarationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AccessibilityDeclarationCreateRequest.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AccessibilityDeclarationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AccessibilityDeclarationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AccessibilityDeclarationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AccessibilityDeclarationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AccessibilityDeclarationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AccessibilityDeclarationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/Actor.swift
+++ b/Sources/BagbutikAppStoreModels/Actor.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ActorResponse.swift
+++ b/Sources/BagbutikAppStoreModels/ActorResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ActorsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/ActorsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AgeRatingDeclaration.swift
+++ b/Sources/BagbutikAppStoreModels/AgeRatingDeclaration.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AgeRatingDeclarationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AgeRatingDeclarationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AgeRatingDeclarationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AgeRatingDeclarationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetail.swift
+++ b/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetail.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AndroidToIosAppMappingDetailsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppAccessibilityDeclarationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAccessibilityDeclarationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAccessibilityDeclarationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAndroidToIosAppMappingDetailsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAndroidToIosAppMappingDetailsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppAppAvailabilityV2LinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppAvailabilityV2LinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppAvailabilityV2LinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppAppClipsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppClipsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppClipsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppCustomProductPagesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppCustomProductPagesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppCustomProductPagesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppEncryptionDeclarationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppEncryptionDeclarationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppEncryptionDeclarationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppEventsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppEventsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppEventsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppInfosLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppInfosLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppInfosLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppPricePointsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppPricePointsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppPricePointsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppPriceScheduleLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppPriceScheduleLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppPriceScheduleLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppAppStoreVersionExperimentsV2LinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppStoreVersionExperimentsV2LinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppStoreVersionExperimentsV2LinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppStoreVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppStoreVersionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAppStoreVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppAppTagsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAppTagsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppAvailabilityV2.swift
+++ b/Sources/BagbutikAppStoreModels/AppAvailabilityV2.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppAvailabilityV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppAvailabilityV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppAvailabilityV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/AppAvailabilityV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppAvailabilityV2TerritoryAvailabilitiesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppAvailabilityV2TerritoryAvailabilitiesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppAvailabilityV2TerritoryAvailabilitiesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppBackgroundAssetsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppBackgroundAssetsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppBuildUploadsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppBuildUploadsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppBuildsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppBuildsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppBuildsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppCategoriesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCategoriesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCategoriesWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCategoriesWithoutIncludesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCategory.swift
+++ b/Sources/BagbutikAppStoreModels/AppCategory.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCategoryParentLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCategoryParentLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppCategoryParentLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppCategoryResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCategoryResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCategorySubcategoriesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCategorySubcategoriesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppCategorySubcategoriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppCategoryWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCategoryWithoutIncludesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClip.swift
+++ b/Sources/BagbutikAppStoreModels/AppClip.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAction.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAction.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum AppClipAction: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperience.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperience.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImage.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImage.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImageCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImageCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImageUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceImageUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceLanguage.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceLanguage.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum AppClipAdvancedExperienceLanguage: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceLocalizationInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceLocalizationInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperienceUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAdvancedExperiencesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAdvancedExperiencesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAppClipAdvancedExperiencesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAppClipAdvancedExperiencesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppClipAppClipAdvancedExperiencesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppClipAppClipDefaultExperiencesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAppClipDefaultExperiencesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppClipAppClipDefaultExperiencesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetail.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetail.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetailCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetailCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetailResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetailResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetailUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipAppStoreReviewDetailUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperience.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperience.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceAppClipAppStoreReviewDetailLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceAppClipAppStoreReviewDetailLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceAppClipDefaultExperienceLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceAppClipDefaultExperienceLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppClipDefaultExperienceAppClipDefaultExperienceLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationAppClipHeaderImageLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationAppClipHeaderImageLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppClipDefaultExperienceLocalizationAppClipHeaderImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperienceUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDefaultExperiencesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDefaultExperiencesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDomainStatus.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDomainStatus.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipDomainStatusResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipDomainStatusResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipHeaderImage.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipHeaderImage.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipHeaderImageCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipHeaderImageCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipHeaderImageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipHeaderImageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipHeaderImageUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipHeaderImageUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppClipsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppClipsResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPage.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPage.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageAppCustomProductPageVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageAppCustomProductPageVersionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationAppPreviewSetsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationAppPreviewSetsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationAppScreenshotSetsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationAppScreenshotSetsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationSearchKeywordsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationSearchKeywordsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationSearchKeywordsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationSearchKeywordsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageVersion.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageVersion.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionAppCustomProductPageLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionAppCustomProductPageLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppCustomProductPageVersionAppCustomProductPageLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPageVersionsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomProductPagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomProductPagesResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppCustomerReviewsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppCustomerReviewsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppCustomerReviewsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclaration.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclaration.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationAppEncryptionDeclarationDocumentLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationAppEncryptionDeclarationDocumentLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppEncryptionDeclarationAppEncryptionDeclarationDocumentLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppEncryptionDeclarationAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationBuildsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationBuildsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocument.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocument.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocumentCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocumentCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocumentResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocumentResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocumentUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationDocumentUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationState.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum AppEncryptionDeclarationState: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationWithoutIncludesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEncryptionDeclarationsResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEndUserLicenseAgreementLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEndUserLicenseAgreementLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppEndUserLicenseAgreementLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppEvent.swift
+++ b/Sources/BagbutikAppStoreModels/AppEvent.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventAssetType.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventAssetType.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum AppEventAssetType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/AppEventCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventLocalizationAppEventScreenshotsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalizationAppEventScreenshotsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppEventLocalizationAppEventScreenshotsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppEventLocalizationAppEventVideoClipsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalizationAppEventVideoClipsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppEventLocalizationAppEventVideoClipsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppEventLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppEventLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppEventLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventScreenshot.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventScreenshot.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventScreenshotCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventScreenshotCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventScreenshotResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventScreenshotResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventScreenshotUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventScreenshotUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventScreenshotsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventScreenshotsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventVideoClip.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventVideoClip.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventVideoClipCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventVideoClipCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventVideoClipResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventVideoClipResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventVideoClipUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventVideoClipUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventVideoClipsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventVideoClipsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppEventsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppEventsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInAppPurchasesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInAppPurchasesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInAppPurchasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppInAppPurchasesV2LinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInAppPurchasesV2LinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInAppPurchasesV2LinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppInfo.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfo.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoAgeRatingDeclarationLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoAgeRatingDeclarationLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoAgeRatingDeclarationLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppInfoAppInfoLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoAppInfoLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoAppInfoLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppInfoLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoPrimaryCategoryLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoPrimaryCategoryLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoPrimaryCategoryLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppInfoPrimarySubcategoryOneLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoPrimarySubcategoryOneLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoPrimarySubcategoryOneLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppInfoPrimarySubcategoryTwoLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoPrimarySubcategoryTwoLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoPrimarySubcategoryTwoLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppInfoResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoSecondaryCategoryLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoSecondaryCategoryLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoSecondaryCategoryLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppInfoSecondarySubcategoryOneLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoSecondarySubcategoryOneLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoSecondarySubcategoryOneLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppInfoSecondarySubcategoryTwoLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoSecondarySubcategoryTwoLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppInfoSecondarySubcategoryTwoLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppInfoTerritoryAgeRatingsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoTerritoryAgeRatingsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfoUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfoUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppInfosResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppInfosResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppKeyword.swift
+++ b/Sources/BagbutikAppStoreModels/AppKeyword.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppKeywordsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppKeywordsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppMediaAssetState.swift
+++ b/Sources/BagbutikAppStoreModels/AppMediaAssetState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppMediaPreviewFrameImageState.swift
+++ b/Sources/BagbutikAppStoreModels/AppMediaPreviewFrameImageState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppMediaStateError.swift
+++ b/Sources/BagbutikAppStoreModels/AppMediaStateError.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppMediaVideoState.swift
+++ b/Sources/BagbutikAppStoreModels/AppMediaVideoState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreview.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreview.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewSet.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewSet.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewSetAppPreviewsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewSetAppPreviewsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewSetAppPreviewsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewSetAppPreviewsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewSetCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewSetCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewSetResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewSetResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewSetsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewSetsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPreviewsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPreviewsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPricePointV3.swift
+++ b/Sources/BagbutikAppStoreModels/AppPricePointV3.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPricePointV3EqualizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPricePointV3EqualizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppPricePointV3EqualizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppPricePointV3Response.swift
+++ b/Sources/BagbutikAppStoreModels/AppPricePointV3Response.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPricePointsV3Response.swift
+++ b/Sources/BagbutikAppStoreModels/AppPricePointsV3Response.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPriceSchedule.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceSchedule.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPriceScheduleAutomaticPricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceScheduleAutomaticPricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppPriceScheduleAutomaticPricesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppPriceScheduleBaseTerritoryLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceScheduleBaseTerritoryLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppPriceScheduleBaseTerritoryLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppPriceScheduleCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceScheduleCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPriceScheduleManualPricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceScheduleManualPricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppPriceScheduleManualPricesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppPriceScheduleResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceScheduleResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPriceV2.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceV2.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPriceV2InlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/AppPriceV2InlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPricesV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/AppPricesV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPromotedPurchasesLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppPromotedPurchasesLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppPromotedPurchasesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppPromotedPurchasesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
 import BagbutikTestFlightModels
 import BagbutikXcodeCloudModels

--- a/Sources/BagbutikAppStoreModels/AppReviewSubmissionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppReviewSubmissionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshot.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshot.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotSet.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotSet.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotSetAppScreenshotsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotSetAppScreenshotsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotSetAppScreenshotsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotSetAppScreenshotsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotSetCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotSetCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotSetResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotSetResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotSetsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotSetsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppScreenshotsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppScreenshotsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppSearchKeywordsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppSearchKeywordsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreAgeRating.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreAgeRating.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum AppStoreAgeRating: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewAttachment.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewAttachment.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewAttachmentsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewDetail.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewDetail.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewDetailAppStoreReviewAttachmentsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewDetailAppStoreReviewAttachmentsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreReviewDetailAppStoreReviewAttachmentsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewDetailCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewDetailCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewDetailResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewDetailResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreReviewDetailUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreReviewDetailUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersion.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersion.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppClipDefaultExperienceLinkageRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppClipDefaultExperienceLinkageRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppClipDefaultExperienceLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppClipDefaultExperienceLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreReviewDetailLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreReviewDetailLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionAppStoreReviewDetailLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionExperimentsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionExperimentsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionAppStoreVersionExperimentsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionExperimentsV2LinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionExperimentsV2LinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionAppStoreVersionExperimentsV2LinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionAppStoreVersionLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionPhasedReleaseLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionPhasedReleaseLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionAppStoreVersionPhasedReleaseLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionSubmissionLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionAppStoreVersionSubmissionLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionAppStoreVersionSubmissionLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionBuildLinkageRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionBuildLinkageRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionBuildLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionBuildLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionCustomerReviewsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionCustomerReviewsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionCustomerReviewsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperiment.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperiment.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperiment: Codable, Sendable, Identifiable {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentAppStoreVersionExperimentTreatmentsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentAppStoreVersionExperimentTreatmentsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentAppStoreVersionExperimentTreatmentsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentCreateRequest: Codable, Sendable, RequestBody {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatment.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatment.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentAppStoreVersionExperimentTreatmentLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentAppStoreVersionExperimentTreatmentLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentTreatmentAppStoreVersionExperimentTreatmentLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationAppPreviewSetsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationAppPreviewSetsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentTreatmentLocalizationAppPreviewSetsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationAppScreenshotSetsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationAppScreenshotSetsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentTreatmentLocalizationAppScreenshotSetsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentTreatmentsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentUpdateRequest: Codable, Sendable, RequestBody {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2AppStoreVersionExperimentTreatmentsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2AppStoreVersionExperimentTreatmentsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentV2AppStoreVersionExperimentTreatmentsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2Response.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2UpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentV2UpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionExperimentsResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentsV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionExperimentsV2Response.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationAppPreviewSetsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationAppPreviewSetsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionLocalizationAppPreviewSetsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationAppScreenshotSetsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationAppScreenshotSetsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionLocalizationAppScreenshotSetsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationSearchKeywordsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationSearchKeywordsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationSearchKeywordsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationSearchKeywordsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedRelease.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedRelease.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPhasedReleaseWithoutIncludesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPromotion.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPromotion.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPromotionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPromotionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionPromotionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionPromotionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionReleaseRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionReleaseRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionReleaseRequestCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionReleaseRequestCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionReleaseRequestResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionReleaseRequestResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionResponse.swift
@@ -1,8 +1,6 @@
 import BagbutikCore
 import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionRoutingAppCoverageLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionRoutingAppCoverageLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppStoreVersionRoutingAppCoverageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionState.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum AppStoreVersionState: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionSubmission.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionSubmission.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionSubmissionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionSubmissionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppStoreVersionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppStoreVersionsResponse.swift
@@ -1,8 +1,6 @@
 import BagbutikCore
 import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppSubscriptionGracePeriodLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppSubscriptionGracePeriodLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppSubscriptionGracePeriodLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/AppSubscriptionGroupsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppSubscriptionGroupsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct AppSubscriptionGroupsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/AppTag.swift
+++ b/Sources/BagbutikAppStoreModels/AppTag.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppTagResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppTagResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppTagTerritoriesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppTagTerritoriesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppTagUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppTagUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppTagsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppTagsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/AppUpdateRequest.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppVersionState.swift
+++ b/Sources/BagbutikAppStoreModels/AppVersionState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum AppVersionState: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/AppWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppWithoutIncludesResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/AppsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
 import BagbutikTestFlightModels
 import BagbutikXcodeCloudModels

--- a/Sources/BagbutikAppStoreModels/AppsWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/AppsWithoutIncludesResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAsset.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAsset.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFile.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFile.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFileCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFileCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFileResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFileResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFileUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFileUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFilesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetUploadFilesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersion.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersion.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionAppStoreRelease.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionAppStoreRelease.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionAppStoreReleaseResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionAppStoreReleaseResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionAppStoreReleaseState.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionAppStoreReleaseState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum BackgroundAssetVersionAppStoreReleaseState: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionBackgroundAssetUploadFilesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionBackgroundAssetUploadFilesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionExternalBetaRelease.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionExternalBetaRelease.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionExternalBetaReleaseResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionExternalBetaReleaseResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionExternalBetaReleaseState.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionExternalBetaReleaseState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum BackgroundAssetVersionExternalBetaReleaseState: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionInternalBetaRelease.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionInternalBetaRelease.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionInternalBetaReleaseResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionInternalBetaReleaseResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionState.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum BackgroundAssetVersionState: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetVersionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetVersionsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BackgroundAssetsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BackgroundAssetsResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BetaAppLocalizationAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaAppLocalizationAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BetaAppLocalizationAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BetaAppReviewDetailAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaAppReviewDetailAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BetaAppReviewDetailAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BetaAppReviewSubmissionBuildLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaAppReviewSubmissionBuildLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BetaAppReviewSubmissionBuildLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BetaBuildLocalizationBuildLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaBuildLocalizationBuildLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BetaBuildLocalizationBuildLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BetaGroupAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaGroupAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BetaGroupAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BetaGroupBuildsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BetaGroupBuildsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BetaGroupBuildsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaGroupBuildsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BetaLicenseAgreementAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaLicenseAgreementAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BetaLicenseAgreementAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BetaTesterAppsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BetaTesterAppsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BetaTesterAppsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaTesterAppsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BetaTesterBuildsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BetaTesterBuildsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BetaTesterBuildsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BetaTesterBuildsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BrazilAgeRating.swift
+++ b/Sources/BagbutikAppStoreModels/BrazilAgeRating.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum BrazilAgeRating: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/BuildAppEncryptionDeclarationLinkageRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BuildAppEncryptionDeclarationLinkageRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildAppEncryptionDeclarationLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildAppEncryptionDeclarationLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BuildAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BuildAppStoreVersionLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildAppStoreVersionLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BuildAppStoreVersionLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BuildBetaDetailBuildLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBetaDetailBuildLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BuildBetaDetailBuildLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BuildBundle.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBundle.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildBundleAppClipDomainCacheStatusLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBundleAppClipDomainCacheStatusLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BuildBundleAppClipDomainCacheStatusLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BuildBundleAppClipDomainDebugStatusLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBundleAppClipDomainDebugStatusLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BuildBundleAppClipDomainDebugStatusLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/BuildBundleBuildBundleFileSizesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBundleBuildBundleFileSizesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BuildBundleBuildBundleFileSizesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/BuildBundleFileSize.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBundleFileSize.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildBundleFileSizesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBundleFileSizesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildBundleType.swift
+++ b/Sources/BagbutikAppStoreModels/BuildBundleType.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum BuildBundleType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/BuildIcon.swift
+++ b/Sources/BagbutikAppStoreModels/BuildIcon.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildIconsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildIconsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BuildIconsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/BuildIconsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildIconsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildIconsWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildIconsWithoutIncludesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildResponse.swift
@@ -1,8 +1,6 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
 import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUpload.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUpload.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadBuildUploadFilesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadBuildUploadFilesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadFile.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadFile.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadFileCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadFileCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadFileResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadFileResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadFileUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadFileUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadFilesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadFilesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildUploadState.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum BuildUploadState: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/BuildUploadsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildUploadsResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildWithoutIncludesResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildsResponse.swift
@@ -1,8 +1,6 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
 import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BuildsWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BuildsWithoutIncludesResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/BundleIdAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/BundleIdAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct BundleIdAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/CiBuildRunBuildsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/CiBuildRunBuildsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct CiBuildRunBuildsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/CiProductAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/CiProductAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct CiProductAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/CustomerReview.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReview.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/CustomerReviewResponse.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/CustomerReviewResponseLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewResponseLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct CustomerReviewResponseLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/CustomerReviewResponseV1.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewResponseV1.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/CustomerReviewResponseV1CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewResponseV1CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/CustomerReviewResponseV1Response.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewResponseV1Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/CustomerReviewSummarization.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewSummarization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/CustomerReviewSummarizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewSummarizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/CustomerReviewsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/CustomerReviewsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/DeliveryFileUploadOperation.swift
+++ b/Sources/BagbutikAppStoreModels/DeliveryFileUploadOperation.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndAppAvailabilityPreOrder.swift
+++ b/Sources/BagbutikAppStoreModels/EndAppAvailabilityPreOrder.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndAppAvailabilityPreOrderCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/EndAppAvailabilityPreOrderCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndAppAvailabilityPreOrderResponse.swift
+++ b/Sources/BagbutikAppStoreModels/EndAppAvailabilityPreOrderResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndUserLicenseAgreement.swift
+++ b/Sources/BagbutikAppStoreModels/EndUserLicenseAgreement.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementResponse.swift
+++ b/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementTerritoriesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementTerritoriesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct EndUserLicenseAgreementTerritoriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/EndUserLicenseAgreementWithoutIncludesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/GameCenterAppVersionAppStoreVersionLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/GameCenterAppVersionAppStoreVersionLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct GameCenterAppVersionAppStoreVersionLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/IconAssetType.swift
+++ b/Sources/BagbutikAppStoreModels/IconAssetType.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum IconAssetType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchase.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchase.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshot.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshot.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshotCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshotCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshotResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshotResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshotUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAppStoreReviewScreenshotUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAvailability.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAvailability.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAvailabilityAvailableTerritoriesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAvailabilityAvailableTerritoriesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseAvailabilityAvailableTerritoriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAvailabilityCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAvailabilityCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseAvailabilityResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseAvailabilityResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseContent.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseContent.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseContentResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseContentResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImage.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImage.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImageCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImageCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImageUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImageUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2UpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImageV2UpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseImagesV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseImagesV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2UpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationV2UpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationsV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseLocalizationsV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCode.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCode.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCode.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCode.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodeCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodeCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodeResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodeResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodeUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodeUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeCustomCodesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCode.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCode.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeValue.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodeValue.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeOneTimeUseCodesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodePricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodePricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodeUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferCodesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferPrice.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferPrice.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferPriceInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferPriceInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseOfferPricesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseOfferPricesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePrice.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePrice.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePriceInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePriceInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePricePoint.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePricePoint.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePricePointEqualizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePricePointEqualizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchasePricePointEqualizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePricePointsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePricePointsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePriceSchedule.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePriceSchedule.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleAutomaticPricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleAutomaticPricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchasePriceScheduleAutomaticPricesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleBaseTerritoryLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleBaseTerritoryLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchasePriceScheduleBaseTerritoryLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleManualPricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleManualPricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchasePriceScheduleManualPricesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePriceScheduleResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasePricesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasePricesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseState.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum InAppPurchaseState: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseSubmission.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseSubmission.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseSubmissionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseSubmissionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseSubmissionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseSubmissionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseType.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseType.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum InAppPurchaseType: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2AppStoreReviewScreenshotLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2AppStoreReviewScreenshotLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2AppStoreReviewScreenshotLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2ContentLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2ContentLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2ContentLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2IapPriceScheduleLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2IapPriceScheduleLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2IapPriceScheduleLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2ImagesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2ImagesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2ImagesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2InAppPurchaseAvailabilityLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2InAppPurchaseAvailabilityLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2InAppPurchaseAvailabilityLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2InAppPurchaseLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2InAppPurchaseLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2InAppPurchaseLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2OfferCodesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2OfferCodesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2PricePointsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2PricePointsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2PricePointsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2PromotedPurchaseLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2PromotedPurchaseLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct InAppPurchaseV2PromotedPurchaseLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2UpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2UpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseV2VersionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseV2VersionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseVersion.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseVersion.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseVersionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseVersionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseVersionImageLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseVersionImageLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseVersionImagesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseVersionImagesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseVersionLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseVersionLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseVersionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseVersionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchaseVersionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchaseVersionsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasesResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/InAppPurchasesV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/InAppPurchasesV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/KidsAgeBand.swift
+++ b/Sources/BagbutikAppStoreModels/KidsAgeBand.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum KidsAgeBand: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/Nomination.swift
+++ b/Sources/BagbutikAppStoreModels/Nomination.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/NominationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/NominationCreateRequest.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/NominationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/NominationResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/NominationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/NominationUpdateRequest.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/NominationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/NominationsResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/OfferCodeEnvironment.swift
+++ b/Sources/BagbutikAppStoreModels/OfferCodeEnvironment.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum OfferCodeEnvironment: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/PhasedReleaseState.swift
+++ b/Sources/BagbutikAppStoreModels/PhasedReleaseState.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum PhasedReleaseState: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/PrereleaseVersionAppLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/PrereleaseVersionAppLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct PrereleaseVersionAppLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/PrereleaseVersionBuildsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/PrereleaseVersionBuildsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct PrereleaseVersionBuildsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/PreviewFrameImage.swift
+++ b/Sources/BagbutikAppStoreModels/PreviewFrameImage.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/PreviewType.swift
+++ b/Sources/BagbutikAppStoreModels/PreviewType.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum PreviewType: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/PromotedPurchase.swift
+++ b/Sources/BagbutikAppStoreModels/PromotedPurchase.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/PromotedPurchaseCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/PromotedPurchaseCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/PromotedPurchaseResponse.swift
+++ b/Sources/BagbutikAppStoreModels/PromotedPurchaseResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/PromotedPurchaseUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/PromotedPurchaseUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/PromotedPurchasesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/PromotedPurchasesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmission.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmission.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionItem.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionItem.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionItemCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionItemCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionItemResponse.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionItemResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionItemUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionItemUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionItemsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionItemsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionItemsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionItemsResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ReviewSubmissionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/ReviewSubmissionsResponse.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/RoutingAppCoverage.swift
+++ b/Sources/BagbutikAppStoreModels/RoutingAppCoverage.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/RoutingAppCoverageCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/RoutingAppCoverageCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/RoutingAppCoverageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/RoutingAppCoverageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/RoutingAppCoverageUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/RoutingAppCoverageUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/ScreenshotDisplayType.swift
+++ b/Sources/BagbutikAppStoreModels/ScreenshotDisplayType.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum ScreenshotDisplayType: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/Subscription.swift
+++ b/Sources/BagbutikAppStoreModels/Subscription.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshot.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshot.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionAppStoreReviewScreenshotLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAppStoreReviewScreenshotUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionAvailability.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAvailability.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionAvailabilityAvailableTerritoriesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAvailabilityAvailableTerritoriesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionAvailabilityAvailableTerritoriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionAvailabilityCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAvailabilityCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionAvailabilityResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionAvailabilityResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionCustomerEligibility.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionCustomerEligibility.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum SubscriptionCustomerEligibility: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionGracePeriod.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGracePeriod.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGracePeriodDuration.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGracePeriodDuration.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum SubscriptionGracePeriodDuration: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionGracePeriodResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGracePeriodResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGracePeriodUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGracePeriodUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroup.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroup.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2UpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationV2UpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationsV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupLocalizationsV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupSubmission.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupSubmission.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupSubmissionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupSubmissionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupSubmissionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupSubmissionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupSubscriptionGroupLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupSubscriptionGroupLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionGroupSubscriptionGroupLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupSubscriptionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupSubscriptionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupVersion.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupVersion.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupVersionsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionGroupsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionGroupsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImage.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImage.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImageCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImageCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImageUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImageUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImageV2.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImageV2.swift
@@ -1,8 +1,5 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
 import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImageV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImageV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImageV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImageV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImageV2UpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImageV2UpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImagesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImagesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionImagesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionImagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionImagesV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionImagesV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffer.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffer.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOfferUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffersLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffersLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffersLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffersLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffersResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionIntroductoryOffersResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalization.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalization.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2CreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2CreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2UpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationV2UpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionLocalizationsV2Response.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionLocalizationsV2Response.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCode.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCode.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCode.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCode.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodeCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodeCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodeResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodeResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodeUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodeUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionOfferCodeCustomCodesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeCustomCodesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCode.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCode.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeValue.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodeValue.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionOfferCodeOneTimeUseCodesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeOneTimeUseCodesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePrice.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePrice.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePriceInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePriceInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionOfferCodePricesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePricesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodePricesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodeUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionOfferCodesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferCodesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferCodesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferDuration.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferDuration.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum SubscriptionOfferDuration: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferEligibility.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferEligibility.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum SubscriptionOfferEligibility: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionOfferMode.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionOfferMode.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum SubscriptionOfferMode: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilitiesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilitiesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilitiesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilitiesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailability.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailability.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityAvailableTerritoriesLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityAvailableTerritoriesLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityAvailableTerritoriesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityAvailableTerritoriesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanAvailabilityUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPlanType.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPlanType.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public enum SubscriptionPlanType: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionPrice.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPrice.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPriceCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPriceCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPriceInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPriceInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricePoint.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricePoint.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricePointEqualizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricePointEqualizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionPricePointEqualizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricePointInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricePointInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricePointResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricePointResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricePointsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricePointsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionPricePointsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricePointsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricePointsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPriceResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPriceResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricesLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricesLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPricesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPricesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotedPurchaseLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotedPurchaseLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionPromotedPurchaseLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOffer.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOffer.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPrice.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPrice.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPriceInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPriceInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionPromotionalOfferPricesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPricesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferPricesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOfferUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOffersLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOffersLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionPromotionalOffersLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOffersResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionPromotionalOffersResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionSubmission.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionSubmission.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionSubmissionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionSubmissionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionSubmissionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionSubmissionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionSubscriptionAvailabilityLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionSubscriptionAvailabilityLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionSubscriptionAvailabilityLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikAppStoreModels/SubscriptionSubscriptionLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionSubscriptionLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionSubscriptionLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersion.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersion.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersionCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersionCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersionImageLinkageResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersionImageLinkageResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersionImagesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersionImagesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersionLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersionLocalizationsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersionResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersionResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersionsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionVersionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionVersionsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/SubscriptionWinBackOffersLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionWinBackOffersLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct SubscriptionWinBackOffersLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/SubscriptionsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/SubscriptionsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoriesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoriesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoriesWithoutIncludesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoriesWithoutIncludesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/Territory.swift
+++ b/Sources/BagbutikAppStoreModels/Territory.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryAgeRating.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryAgeRating.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryAgeRatingsResponse.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryAgeRatingsResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryAvailabilitiesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryAvailabilitiesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryAvailability.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryAvailability.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryAvailabilityInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryAvailabilityInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryAvailabilityResponse.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryAvailabilityResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryAvailabilityUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryAvailabilityUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/TerritoryResponse.swift
+++ b/Sources/BagbutikAppStoreModels/TerritoryResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/UserInvitationVisibleAppsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/UserInvitationVisibleAppsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct UserInvitationVisibleAppsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/UserVisibleAppsLinkagesRequest.swift
+++ b/Sources/BagbutikAppStoreModels/UserVisibleAppsLinkagesRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/UserVisibleAppsLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/UserVisibleAppsLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOffer.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOffer.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOfferCreateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOfferCreateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOfferPrice.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOfferPrice.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOfferPriceInlineCreate.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOfferPriceInlineCreate.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOfferPricesLinkagesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOfferPricesLinkagesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 public struct WinBackOfferPricesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikAppStoreModels/WinBackOfferPricesResponse.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOfferPricesResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOfferResponse.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOfferResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOfferUpdateRequest.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOfferUpdateRequest.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikAppStoreModels/WinBackOffersResponse.swift
+++ b/Sources/BagbutikAppStoreModels/WinBackOffersResponse.swift
@@ -1,8 +1,4 @@
 import BagbutikCore
-import BagbutikMarketplacesModels
-import BagbutikModelsShared
-import BagbutikTestFlightModels
-import BagbutikXcodeCloudModels
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/AppGameCenterDetailLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/AppGameCenterDetailLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppGameCenterDetailLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/AppGameCenterEnabledVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/AppGameCenterEnabledVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppGameCenterEnabledVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/AppStoreVersionGameCenterAppVersionLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/AppStoreVersionGameCenterAppVersionLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppStoreVersionGameCenterAppVersionLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievement.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievement.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementActivityLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementActivityLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterAchievementActivityLinkageRequest: Codable, Sendable, RequestBody {

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementGroupAchievementLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementGroupAchievementLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementGroupAchievementLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementGroupAchievementLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementImageCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementImageCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementImageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementImageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementImageUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementImageUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementImageV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementImageV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementImageV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementImageV2Response.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementImageV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementImageV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalization.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalization.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationGameCenterAchievementImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationGameCenterAchievementImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterAchievementLocalizationGameCenterAchievementImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationGameCenterAchievementLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationGameCenterAchievementLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterAchievementLocalizationGameCenterAchievementLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2ImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2ImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterAchievementLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationsResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementLocalizationsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementRelease.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementRelease.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementReleaseCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementReleaseCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementReleaseResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementReleaseResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterAchievementReleasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementReleasesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementReleasesResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementV2.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementV2.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementV2ActivityLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementV2ActivityLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementV2VersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementV2VersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2InlineCreate.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2InlineCreate.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2LocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2LocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementVersionsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAchievementsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAchievementsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivitiesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivitiesResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivity.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivity.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityAchievementsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityAchievementsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityAchievementsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityAchievementsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityImageCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityImageCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityImageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityImageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityImageUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityImageUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLeaderboardsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLeaderboardsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLeaderboardsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLeaderboardsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLocalization.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLocalization.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterActivityLocalizationImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityLocalizationsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionDefaultImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionDefaultImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterActivityVersionDefaultImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionInlineCreate.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionInlineCreate.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionLocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterActivityVersionLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionRelease.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionRelease.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionReleaseCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionReleaseCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionReleaseResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionReleaseResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionReleasesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionReleasesResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterActivityVersionsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterActivityVersionsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterAppVersionCompatibilityVersionsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAppVersionCompatibilityVersionsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAppVersionCompatibilityVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAppVersionCompatibilityVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAppVersionCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAppVersionCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterAppVersionUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterAppVersionUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallenge.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallenge.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeImageCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeImageCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeImageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeImageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeImageUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeImageUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLeaderboardLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLeaderboardLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterChallengeLeaderboardLinkageRequest: Codable, Sendable, RequestBody {

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLeaderboardV2LinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLeaderboardV2LinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalization.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalization.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterChallengeLocalizationImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeLocalizationsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionDefaultImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionDefaultImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterChallengeVersionDefaultImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionInlineCreate.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionInlineCreate.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionLocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterChallengeVersionLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionRelease.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionRelease.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionReleaseCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionReleaseCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionReleaseResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionReleaseResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionReleasesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionReleasesResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterChallengeVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengeVersionsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterChallengesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterChallengesResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailAchievementReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailAchievementReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailAchievementReleasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailActivityReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailActivityReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailActivityReleasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailChallengeReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailChallengeReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailChallengesMinimumPlatformVersionsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailChallengesMinimumPlatformVersionsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsV2LinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAchievementsV2LinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterActivitiesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterActivitiesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailGameCenterActivitiesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAppVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterAppVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailGameCenterAppVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterChallengesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterChallengesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailGameCenterChallengesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterGroupLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterGroupLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailGameCenterGroupLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsV2LinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardSetsV2LinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsV2LinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailGameCenterLeaderboardsV2LinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailLeaderboardReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailLeaderboardReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailLeaderboardReleasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailLeaderboardSetReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailLeaderboardSetReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterDetailLeaderboardSetReleasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterDetailUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterDetailUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterEnabledVersionCompatibleVersionsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterEnabledVersionCompatibleVersionsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterEnabledVersionCompatibleVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterEnabledVersionCompatibleVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterEnabledVersionsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterEnabledVersionsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterGroup.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroup.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsV2LinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterAchievementsV2LinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterActivitiesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterActivitiesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterGroupGameCenterActivitiesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterChallengesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterChallengesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterGroupGameCenterChallengesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterDetailsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterDetailsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterGroupGameCenterDetailsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsV2LinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardSetsV2LinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsV2LinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsV2LinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsV2LinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupGameCenterLeaderboardsV2LinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterGroupsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterGroupsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboard.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboard.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardActivityLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardActivityLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardActivityLinkageRequest: Codable, Sendable, RequestBody {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardChallengeLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardChallengeLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardChallengeLinkageRequest: Codable, Sendable, RequestBody {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardEntrySubmission.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardEntrySubmission.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardEntrySubmissionCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardEntrySubmissionCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardEntrySubmissionResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardEntrySubmissionResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardFormatter.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardFormatter.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum GameCenterLeaderboardFormatter: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardGroupLeaderboardLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardGroupLeaderboardLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardGroupLeaderboardLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardGroupLeaderboardLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageV2Response.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardImageV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalization.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalization.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationGameCenterLeaderboardImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationGameCenterLeaderboardImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardLocalizationGameCenterLeaderboardImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2ImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2ImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationsResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardLocalizationsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardRelease.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardRelease.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleaseCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleaseCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleaseResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleaseResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardReleasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleasesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardReleasesResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSet.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSet.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGroupLeaderboardSetLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGroupLeaderboardSetLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageV2Response.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetImageV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalization.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalization.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationGameCenterLeaderboardSetImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationGameCenterLeaderboardSetImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardSetLocalizationGameCenterLeaderboardSetImageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2ImageLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2ImageLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardSetLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationsResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetLocalizationsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalization.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalization.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationGameCenterLeaderboardLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationGameCenterLeaderboardLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardSetMemberLocalizationGameCenterLeaderboardLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationGameCenterLeaderboardSetLinkageResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationGameCenterLeaderboardSetLinkageResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardSetMemberLocalizationGameCenterLeaderboardSetLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetMemberLocalizationsResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetRelease.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetRelease.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleaseCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleaseCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleaseResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleaseResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleasesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleasesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterLeaderboardSetReleasesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleasesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetReleasesResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2GameCenterLeaderboardsLinkagesRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2GameCenterLeaderboardsLinkagesRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2GameCenterLeaderboardsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2GameCenterLeaderboardsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2VersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetV2VersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2InlineCreate.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2InlineCreate.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2LocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2LocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetVersionsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardSetsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2ActivityLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2ActivityLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2ChallengeLinkageRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2ChallengeLinkageRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2UpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2UpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2VersionsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardV2VersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2CreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2CreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2InlineCreate.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2InlineCreate.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2LocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2LocalizationsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardVersionsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardsResponse.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterLeaderboardsV2Response.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterLeaderboardsV2Response.swift
@@ -1,4 +1,3 @@
-import BagbutikAppStoreModels
 import BagbutikCore
 import BagbutikModelsShared
 import Foundation

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingAppRequestsV1MetricResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingAppRequestsV1MetricResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingBooleanRuleResultsV1MetricResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingBooleanRuleResultsV1MetricResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingNumberRuleResultsV1MetricResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingNumberRuleResultsV1MetricResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueue.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueue.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueRequestsV1MetricResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueRequestsV1MetricResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueSizesV1MetricResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueSizesV1MetricResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueueUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueuesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingQueuesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRule.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRule.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleErrorsV1MetricResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleErrorsV1MetricResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSet.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSet.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetMatchmakingQueuesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetMatchmakingQueuesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterMatchmakingRuleSetMatchmakingQueuesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetRulesLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetRulesLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterMatchmakingRuleSetRulesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTeamsLinkagesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTeamsLinkagesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct GameCenterMatchmakingRuleSetTeamsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTestCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTestCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTestResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetTestResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleSetsResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRuleUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRulesResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingRulesResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingSessionsV1MetricResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingSessionsV1MetricResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeam.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeam.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamAssignment.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamAssignment.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamUpdateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamUpdateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamsResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTeamsResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestPlayerProperty.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestPlayerProperty.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestPlayerPropertyInlineCreate.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestPlayerPropertyInlineCreate.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestRequestInlineCreate.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterMatchmakingTestRequestInlineCreate.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterPlayerAchievementSubmission.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterPlayerAchievementSubmission.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterPlayerAchievementSubmissionCreateRequest.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterPlayerAchievementSubmissionCreateRequest.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/GameCenterPlayerAchievementSubmissionResponse.swift
+++ b/Sources/BagbutikGameCenterModels/GameCenterPlayerAchievementSubmissionResponse.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikGameCenterModels/Property.swift
+++ b/Sources/BagbutikGameCenterModels/Property.swift
@@ -1,6 +1,4 @@
-import BagbutikAppStoreModels
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomain.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomain.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomainCreateRequest.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomainCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomainResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomainResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomainsResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionDomainsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionKey.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionKey.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionKeyCreateRequest.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionKeyCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionKeyResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionKeyResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionKeysResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionKeysResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackage.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackage.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageCreateRequest.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageDelta.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageDelta.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageDeltaResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageDeltaResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageDeltasResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageDeltasResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVariant.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVariant.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVariantResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVariantResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVariantsResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVariantsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersion.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersion.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionDeltasLinkagesResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionDeltasLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AlternativeDistributionPackageVersionDeltasLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionVariantsLinkagesResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionVariantsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AlternativeDistributionPackageVersionVariantsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AlternativeDistributionPackageVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionsResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AlternativeDistributionPackageVersionsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/AppAlternativeDistributionKeyLinkageResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AppAlternativeDistributionKeyLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppAlternativeDistributionKeyLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikMarketplacesModels/AppMarketplaceSearchDetailLinkageResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AppMarketplaceSearchDetailLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppMarketplaceSearchDetailLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikMarketplacesModels/AppStoreVersionAlternativeDistributionPackageLinkageResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/AppStoreVersionAlternativeDistributionPackageLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppStoreVersionAlternativeDistributionPackageLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetail.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetail.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetailCreateRequest.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetailCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetailResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetailResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetailUpdateRequest.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceSearchDetailUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceWebhook.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceWebhook.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceWebhookCreateRequest.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceWebhookCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceWebhookResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceWebhookResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceWebhookUpdateRequest.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceWebhookUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikMarketplacesModels/MarketplaceWebhooksResponse.swift
+++ b/Sources/BagbutikMarketplacesModels/MarketplaceWebhooksResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleId.swift
+++ b/Sources/BagbutikProvisioningModels/BundleId.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdBundleIdCapabilitiesLinkagesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdBundleIdCapabilitiesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BundleIdBundleIdCapabilitiesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikProvisioningModels/BundleIdCapabilitiesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdCapabilitiesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdCapabilitiesWithoutIncludesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdCapabilitiesWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdCapability.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdCapability.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdCapabilityCreateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdCapabilityCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdCapabilityResponse.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdCapabilityResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdCapabilityUpdateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdCapabilityUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdCreateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdPlatform.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdPlatform.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum BundleIdPlatform: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikProvisioningModels/BundleIdProfilesLinkagesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdProfilesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BundleIdProfilesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikProvisioningModels/BundleIdUpdateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/BundleIdWithoutIncludesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/BundleIdWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CapabilityOption.swift
+++ b/Sources/BagbutikProvisioningModels/CapabilityOption.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CapabilitySetting.swift
+++ b/Sources/BagbutikProvisioningModels/CapabilitySetting.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CapabilityType.swift
+++ b/Sources/BagbutikProvisioningModels/CapabilityType.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum CapabilityType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikProvisioningModels/Certificate.swift
+++ b/Sources/BagbutikProvisioningModels/Certificate.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CertificateCreateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/CertificateCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CertificatePassTypeIdLinkageResponse.swift
+++ b/Sources/BagbutikProvisioningModels/CertificatePassTypeIdLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CertificateResponse.swift
+++ b/Sources/BagbutikProvisioningModels/CertificateResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CertificateType.swift
+++ b/Sources/BagbutikProvisioningModels/CertificateType.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum CertificateType: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikProvisioningModels/CertificateUpdateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/CertificateUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CertificatesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/CertificatesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/CertificatesWithoutIncludesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/CertificatesWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/Device.swift
+++ b/Sources/BagbutikProvisioningModels/Device.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/DeviceCreateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/DeviceCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/DeviceResponse.swift
+++ b/Sources/BagbutikProvisioningModels/DeviceResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/DeviceUpdateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/DeviceUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/DevicesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/DevicesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/DevicesWithoutIncludesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/DevicesWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/MerchantId.swift
+++ b/Sources/BagbutikProvisioningModels/MerchantId.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/MerchantIdCertificatesLinkagesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/MerchantIdCertificatesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct MerchantIdCertificatesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikProvisioningModels/MerchantIdCreateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/MerchantIdCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/MerchantIdResponse.swift
+++ b/Sources/BagbutikProvisioningModels/MerchantIdResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/MerchantIdUpdateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/MerchantIdUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/MerchantIdsResponse.swift
+++ b/Sources/BagbutikProvisioningModels/MerchantIdsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/PassTypeId.swift
+++ b/Sources/BagbutikProvisioningModels/PassTypeId.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/PassTypeIdCertificatesLinkagesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/PassTypeIdCertificatesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/PassTypeIdCreateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/PassTypeIdCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/PassTypeIdResponse.swift
+++ b/Sources/BagbutikProvisioningModels/PassTypeIdResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/PassTypeIdUpdateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/PassTypeIdUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/PassTypeIdsResponse.swift
+++ b/Sources/BagbutikProvisioningModels/PassTypeIdsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/Profile.swift
+++ b/Sources/BagbutikProvisioningModels/Profile.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/ProfileBundleIdLinkageResponse.swift
+++ b/Sources/BagbutikProvisioningModels/ProfileBundleIdLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct ProfileBundleIdLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikProvisioningModels/ProfileCertificatesLinkagesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/ProfileCertificatesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct ProfileCertificatesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikProvisioningModels/ProfileCreateRequest.swift
+++ b/Sources/BagbutikProvisioningModels/ProfileCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/ProfileDevicesLinkagesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/ProfileDevicesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct ProfileDevicesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikProvisioningModels/ProfileResponse.swift
+++ b/Sources/BagbutikProvisioningModels/ProfileResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/ProfilesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/ProfilesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikProvisioningModels/ProfilesWithoutIncludesResponse.swift
+++ b/Sources/BagbutikProvisioningModels/ProfilesWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReport.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReport.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportInstance.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportInstance.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportInstanceResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportInstanceResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportInstanceSegmentsLinkagesResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportInstanceSegmentsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AnalyticsReportInstanceSegmentsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikReportingModels/AnalyticsReportInstancesLinkagesResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportInstancesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AnalyticsReportInstancesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikReportingModels/AnalyticsReportInstancesResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportInstancesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportRequest.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportRequestCreateRequest.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportRequestCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportRequestReportsLinkagesResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportRequestReportsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AnalyticsReportRequestReportsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikReportingModels/AnalyticsReportRequestResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportRequestResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportRequestsResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportRequestsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportSegment.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportSegment.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportSegmentResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportSegmentResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportSegmentsResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportSegmentsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AnalyticsReportsResponse.swift
+++ b/Sources/BagbutikReportingModels/AnalyticsReportsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/AppAnalyticsReportRequestsLinkagesResponse.swift
+++ b/Sources/BagbutikReportingModels/AppAnalyticsReportRequestsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppAnalyticsReportRequestsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikReportingModels/BuildDiagnosticSignaturesLinkagesResponse.swift
+++ b/Sources/BagbutikReportingModels/BuildDiagnosticSignaturesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BuildDiagnosticSignaturesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikReportingModels/DiagnosticInsight.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticInsight.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/DiagnosticInsightDirection.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticInsightDirection.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum DiagnosticInsightDirection: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikReportingModels/DiagnosticInsightType.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticInsightType.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum DiagnosticInsightType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikReportingModels/DiagnosticLog.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticLog.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/DiagnosticLogCallStackNode.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticLogCallStackNode.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/DiagnosticLogs.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticLogs.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/DiagnosticSignature.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticSignature.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/DiagnosticSignaturesResponse.swift
+++ b/Sources/BagbutikReportingModels/DiagnosticSignaturesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/MetricCategory.swift
+++ b/Sources/BagbutikReportingModels/MetricCategory.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum MetricCategory: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikReportingModels/MetricsInsight.swift
+++ b/Sources/BagbutikReportingModels/MetricsInsight.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/PerfPowerMetric.swift
+++ b/Sources/BagbutikReportingModels/PerfPowerMetric.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikReportingModels/XcodeMetrics.swift
+++ b/Sources/BagbutikReportingModels/XcodeMetrics.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/AppBetaAppLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppBetaAppLocalizationsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppBetaAppLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikTestFlightModels/AppBetaAppReviewDetailLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppBetaAppReviewDetailLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppBetaAppReviewDetailLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/AppBetaFeedbackCrashSubmissionsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppBetaFeedbackCrashSubmissionsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppBetaFeedbackCrashSubmissionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikTestFlightModels/AppBetaFeedbackScreenshotSubmissionsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppBetaFeedbackScreenshotSubmissionsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppBetaFeedbackScreenshotSubmissionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikTestFlightModels/AppBetaGroupsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppBetaGroupsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppBetaGroupsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikTestFlightModels/AppBetaLicenseAgreementLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppBetaLicenseAgreementLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppBetaLicenseAgreementLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/AppBetaTestersLinkagesRequest.swift
+++ b/Sources/BagbutikTestFlightModels/AppBetaTestersLinkagesRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/AppPreReleaseVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppPreReleaseVersionsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppPreReleaseVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikTestFlightModels/AppsBetaTesterUsagesV1MetricResponse.swift
+++ b/Sources/BagbutikTestFlightModels/AppsBetaTesterUsagesV1MetricResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocation.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocation.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalization.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalization.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationInlineCreate.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationInlineCreate.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationLocalizationUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppClipInvocationsResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppClipInvocationsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppLocalization.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppLocalization.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppLocalizationCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppLocalizationCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppLocalizationUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppLocalizationsWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppLocalizationsWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppReviewDetail.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppReviewDetail.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppReviewDetailUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppReviewDetailUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppReviewDetailWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppReviewDetailWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppReviewSubmission.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppReviewSubmission.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppReviewSubmissionCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppReviewSubmissionCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaAppReviewSubmissionWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaAppReviewSubmissionWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaBuildLocalization.swift
+++ b/Sources/BagbutikTestFlightModels/BetaBuildLocalization.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaBuildLocalizationCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaBuildLocalizationCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaBuildLocalizationUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaBuildLocalizationUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaBuildLocalizationsWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaBuildLocalizationsWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaBuildUsagesV1MetricResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaBuildUsagesV1MetricResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaCrashLog.swift
+++ b/Sources/BagbutikTestFlightModels/BetaCrashLog.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaCrashLogResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaCrashLogResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaFeedbackCrashSubmissionCrashLogLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaFeedbackCrashSubmissionCrashLogLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaFeedbackScreenshotImage.swift
+++ b/Sources/BagbutikTestFlightModels/BetaFeedbackScreenshotImage.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BetaFeedbackScreenshotImage: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/BetaGroup.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroup.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaGroupBetaRecruitmentCriteriaLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroupBetaRecruitmentCriteriaLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BetaGroupBetaRecruitmentCriteriaLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/BetaGroupBetaRecruitmentCriterionCompatibleBuildCheckLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroupBetaRecruitmentCriterionCompatibleBuildCheckLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BetaGroupBetaRecruitmentCriterionCompatibleBuildCheckLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/BetaGroupBetaTestersLinkagesRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroupBetaTestersLinkagesRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaGroupBetaTestersLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroupBetaTestersLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaGroupCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroupCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaGroupUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroupUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaGroupsWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaGroupsWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaInviteType.swift
+++ b/Sources/BagbutikTestFlightModels/BetaInviteType.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum BetaInviteType: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikTestFlightModels/BetaLicenseAgreement.swift
+++ b/Sources/BagbutikTestFlightModels/BetaLicenseAgreement.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaLicenseAgreementUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaLicenseAgreementUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaLicenseAgreementWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaLicenseAgreementWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaPublicLinkUsagesV1MetricResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaPublicLinkUsagesV1MetricResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterion.swift
+++ b/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterion.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionCompatibleBuildCheck.swift
+++ b/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionCompatibleBuildCheck.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionCompatibleBuildCheckResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionCompatibleBuildCheckResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionOptionsResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionOptionsResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaRecruitmentCriterionUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaReviewState.swift
+++ b/Sources/BagbutikTestFlightModels/BetaReviewState.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum BetaReviewState: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikTestFlightModels/BetaTester.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTester.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTesterBetaGroupsLinkagesRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterBetaGroupsLinkagesRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTesterBetaGroupsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterBetaGroupsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTesterCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTesterInvitation.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterInvitation.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTesterInvitationCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterInvitationCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTesterInvitationResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterInvitationResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTesterState.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterState.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum BetaTesterState: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikTestFlightModels/BetaTesterUsagesV1MetricResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTesterUsagesV1MetricResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BetaTestersWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BetaTestersWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildBetaAppReviewSubmissionLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaAppReviewSubmissionLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BuildBetaAppReviewSubmissionLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/BuildBetaBuildLocalizationsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaBuildLocalizationsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BuildBetaBuildLocalizationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikTestFlightModels/BuildBetaDetail.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaDetail.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildBetaDetailUpdateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaDetailUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildBetaGroupsLinkagesRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaGroupsLinkagesRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildBetaNotification.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaNotification.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildBetaNotificationCreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaNotificationCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildBetaNotificationResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBetaNotificationResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildBuildBetaDetailLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBuildBetaDetailLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BuildBuildBetaDetailLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/BuildBundleBetaAppClipInvocationsLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BuildBundleBetaAppClipInvocationsLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BuildBundleBetaAppClipInvocationsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikTestFlightModels/BuildIndividualTestersLinkagesRequest.swift
+++ b/Sources/BagbutikTestFlightModels/BuildIndividualTestersLinkagesRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildIndividualTestersLinkagesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BuildIndividualTestersLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/BuildPreReleaseVersionLinkageResponse.swift
+++ b/Sources/BagbutikTestFlightModels/BuildPreReleaseVersionLinkageResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct BuildPreReleaseVersionLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikTestFlightModels/DeviceConnectionType.swift
+++ b/Sources/BagbutikTestFlightModels/DeviceConnectionType.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum DeviceConnectionType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikTestFlightModels/ExternalBetaState.swift
+++ b/Sources/BagbutikTestFlightModels/ExternalBetaState.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum ExternalBetaState: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikTestFlightModels/InternalBetaState.swift
+++ b/Sources/BagbutikTestFlightModels/InternalBetaState.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum InternalBetaState: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikTestFlightModels/PreReleaseVersionsWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/PreReleaseVersionsWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/PrereleaseVersion.swift
+++ b/Sources/BagbutikTestFlightModels/PrereleaseVersion.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/PrereleaseVersionWithoutIncludesResponse.swift
+++ b/Sources/BagbutikTestFlightModels/PrereleaseVersionWithoutIncludesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/SandboxTesterV2Response.swift
+++ b/Sources/BagbutikTestFlightModels/SandboxTesterV2Response.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/SandboxTestersClearPurchaseHistoryRequestV2.swift
+++ b/Sources/BagbutikTestFlightModels/SandboxTestersClearPurchaseHistoryRequestV2.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/SandboxTestersClearPurchaseHistoryRequestV2CreateRequest.swift
+++ b/Sources/BagbutikTestFlightModels/SandboxTestersClearPurchaseHistoryRequestV2CreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/SandboxTestersClearPurchaseHistoryRequestV2Response.swift
+++ b/Sources/BagbutikTestFlightModels/SandboxTestersClearPurchaseHistoryRequestV2Response.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikTestFlightModels/SandboxTestersV2Response.swift
+++ b/Sources/BagbutikTestFlightModels/SandboxTestersV2Response.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/User.swift
+++ b/Sources/BagbutikUsersModels/User.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UserInvitation.swift
+++ b/Sources/BagbutikUsersModels/UserInvitation.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UserInvitationCreateRequest.swift
+++ b/Sources/BagbutikUsersModels/UserInvitationCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikUsersModels/UserRole.swift
+++ b/Sources/BagbutikUsersModels/UserRole.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum UserRole: String, Sendable, ParameterValue, Codable, CaseIterable {

--- a/Sources/BagbutikUsersModels/UserUpdateRequest.swift
+++ b/Sources/BagbutikUsersModels/UserUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/AppWebhooksLinkagesResponse.swift
+++ b/Sources/BagbutikWebhooksModels/AppWebhooksLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct AppWebhooksLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikWebhooksModels/Webhook.swift
+++ b/Sources/BagbutikWebhooksModels/Webhook.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookCreateRequest.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookDeliveriesLinkagesResponse.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookDeliveriesLinkagesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public struct WebhookDeliveriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikWebhooksModels/WebhookDeliveriesResponse.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookDeliveriesResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookDelivery.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookDelivery.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookDeliveryCreateRequest.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookDeliveryCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookDeliveryResponse.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookDeliveryResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookEvent.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookEvent.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookEventType.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookEventType.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 public enum WebhookEventType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikWebhooksModels/WebhookPing.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookPing.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookPingCreateRequest.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookPingCreateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookPingResponse.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookPingResponse.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikWebhooksModels/WebhookUpdateRequest.swift
+++ b/Sources/BagbutikWebhooksModels/WebhookUpdateRequest.swift
@@ -1,5 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/AppCiProductLinkageResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/AppCiProductLinkageResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct AppCiProductLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikXcodeCloudModels/CiAction.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiAction.swift
@@ -1,6 +1,5 @@
 import BagbutikCore
 import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiActionType.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiActionType.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public enum CiActionType: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikXcodeCloudModels/CiArtifact.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiArtifact.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiArtifactResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiArtifactResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiArtifactsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiArtifactsResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBranchPatterns.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBranchPatterns.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBranchStartCondition.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBranchStartCondition.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBuildAction.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildAction.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBuildActionArtifactsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildActionArtifactsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiBuildActionArtifactsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiBuildActionBuildRunLinkageResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildActionBuildRunLinkageResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiBuildActionBuildRunLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikXcodeCloudModels/CiBuildActionIssuesLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildActionIssuesLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiBuildActionIssuesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiBuildActionResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildActionResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBuildActionTestResultsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildActionTestResultsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiBuildActionTestResultsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiBuildActionsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildActionsResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBuildRun.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildRun.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBuildRunActionsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildRunActionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiBuildRunActionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiBuildRunCreateRequest.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildRunCreateRequest.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBuildRunResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildRunResponse.swift
@@ -1,6 +1,5 @@
 import BagbutikCore
 import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiBuildRunsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiBuildRunsResponse.swift
@@ -1,6 +1,5 @@
 import BagbutikCore
 import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiCompletionStatus.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiCompletionStatus.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public enum CiCompletionStatus: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikXcodeCloudModels/CiExecutionProgress.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiExecutionProgress.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public enum CiExecutionProgress: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikXcodeCloudModels/CiFilesAndFoldersRule.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiFilesAndFoldersRule.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiGitRefKind.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiGitRefKind.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public enum CiGitRefKind: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikXcodeCloudModels/CiGitUser.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiGitUser.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiIssue.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiIssue.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiIssueCounts.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiIssueCounts.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiIssueResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiIssueResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiIssuesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiIssuesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiMacOsVersion.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiMacOsVersion.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiMacOsVersionResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiMacOsVersionResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiMacOsVersionXcodeVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiMacOsVersionXcodeVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiMacOsVersionXcodeVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiMacOsVersionsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiMacOsVersionsResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiManualBranchStartCondition.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiManualBranchStartCondition.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiManualPullRequestStartCondition.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiManualPullRequestStartCondition.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiManualTagStartCondition.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiManualTagStartCondition.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiProduct.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiProduct.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiProductAdditionalRepositoriesLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiProductAdditionalRepositoriesLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiProductAdditionalRepositoriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiProductBuildRunsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiProductBuildRunsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiProductBuildRunsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiProductPrimaryRepositoriesLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiProductPrimaryRepositoriesLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiProductPrimaryRepositoriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiProductWorkflowsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiProductWorkflowsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiProductWorkflowsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiPullRequestStartCondition.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiPullRequestStartCondition.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiScheduledStartCondition.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiScheduledStartCondition.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiStartConditionFileMatcher.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiStartConditionFileMatcher.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiTagPatterns.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTagPatterns.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiTagStartCondition.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTagStartCondition.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiTestDestination.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTestDestination.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiTestDestinationKind.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTestDestinationKind.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public enum CiTestDestinationKind: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikXcodeCloudModels/CiTestResult.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTestResult.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiTestResultResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTestResultResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiTestResultsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTestResultsResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiTestStatus.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiTestStatus.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public enum CiTestStatus: String, Sendable, Codable, CaseIterable {

--- a/Sources/BagbutikXcodeCloudModels/CiWorkflow.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiWorkflow.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiWorkflowBuildRunsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiWorkflowBuildRunsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiWorkflowBuildRunsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiWorkflowCreateRequest.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiWorkflowCreateRequest.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiWorkflowRepositoryLinkageResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiWorkflowRepositoryLinkageResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiWorkflowRepositoryLinkageResponse: Codable, Sendable {

--- a/Sources/BagbutikXcodeCloudModels/CiWorkflowResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiWorkflowResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiWorkflowUpdateRequest.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiWorkflowUpdateRequest.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiWorkflowsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiWorkflowsResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiXcodeVersion.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiXcodeVersion.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiXcodeVersionMacOsVersionsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiXcodeVersionMacOsVersionsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct CiXcodeVersionMacOsVersionsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/CiXcodeVersionResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiXcodeVersionResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/CiXcodeVersionsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/CiXcodeVersionsResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmGitReference.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmGitReference.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmGitReferenceResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmGitReferenceResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmGitReferencesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmGitReferencesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmProvider.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmProvider.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmProviderRepositoriesLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmProviderRepositoriesLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct ScmProviderRepositoriesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/ScmProviderResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmProviderResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmProviderType.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmProviderType.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmProvidersResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmProvidersResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmPullRequest.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmPullRequest.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmPullRequestResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmPullRequestResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmPullRequestsResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmPullRequestsResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmRepositoriesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmRepositoriesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmRepository.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmRepository.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Sources/BagbutikXcodeCloudModels/ScmRepositoryGitReferencesLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmRepositoryGitReferencesLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct ScmRepositoryGitReferencesLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/ScmRepositoryPullRequestsLinkagesResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmRepositoryPullRequestsLinkagesResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 public struct ScmRepositoryPullRequestsLinkagesResponse: Codable, Sendable, PagedResponse {

--- a/Sources/BagbutikXcodeCloudModels/ScmRepositoryResponse.swift
+++ b/Sources/BagbutikXcodeCloudModels/ScmRepositoryResponse.swift
@@ -1,6 +1,4 @@
 import BagbutikCore
-import BagbutikModelsShared
-import BagbutikProvisioningModels
 import Foundation
 
 /**

--- a/Tools/Sources/BagbutikGenerator/Generator.swift
+++ b/Tools/Sources/BagbutikGenerator/Generator.swift
@@ -115,8 +115,9 @@ public class Generator {
                     .formUnion(Self.endpointSchemaNames(for: operation))
             }
         }
+        let schemaReferenceGraph = SchemaReferenceGraph(schemas: schemas)
         let modulePlan = RuntimeModulePlan(
-            graph: SchemaReferenceGraph(schemas: schemas),
+            graph: schemaReferenceGraph,
             packageBySchema: packageBySchema,
             migratedPackages: Self.migratedPackages,
             sharedSchemas: Self.sharedSchemas,
@@ -198,14 +199,16 @@ public class Generator {
 
         try await withThrowingTaskGroup(of: RenderResult.self) { taskGroup in
             for schema in schemas.values {
-                taskGroup.addTask { [docsLoader, schemas, packageBySchema, modulePlan] in
+                taskGroup.addTask { [docsLoader, schemas, packageBySchema, schemaReferenceGraph, modulePlan] in
                     let packageName = packageBySchema[schema.name]!
                     let modelModule = modulePlan[schema.name]
+                    let referencedModelModules = Set(schemaReferenceGraph.references[schema.name, default: []]
+                        .map { modulePlan[$0] })
                     let model = try await Generator.generateModel(
                         for: schema,
                         packageName: packageName,
                         modelModule: modelModule,
-                        moduleDependencies: modulePlan.dependencies(for: modelModule),
+                        referencedModelModules: referencedModelModules,
                         otherSchemas: schemas,
                         docsLoader: docsLoader
                     )
@@ -353,7 +356,7 @@ public class Generator {
         for schema: Schema,
         packageName: PackageName,
         modelModule: RuntimeModulePlan.ModelModule? = nil,
-        moduleDependencies: Set<RuntimeModulePlan.ModelModule>? = nil,
+        referencedModelModules: Set<RuntimeModulePlan.ModelModule>? = nil,
         otherSchemas: [String: Schema],
         docsLoader: DocsLoader
     )
@@ -375,12 +378,16 @@ public class Generator {
         var imports = ["import Foundation"]
         switch modelModule {
         case .modelsShared:
-            let dependencies = moduleDependencies ?? [.core]
+            let dependencies = (referencedModelModules ?? [])
+                .union([.core])
+                .subtracting([.modelsShared, .legacyModels])
             imports.append(contentsOf: dependencies
                 .sorted { $0.targetName < $1.targetName }
                 .map { "import \($0.targetName)" })
-        case .domainModels:
-            let dependencies = moduleDependencies ?? [.core, .modelsShared]
+        case let .domainModels(package):
+            let dependencies = (referencedModelModules ?? [])
+                .union([.core])
+                .subtracting([.domainModels(package), .legacyModels])
             imports.append(contentsOf: dependencies
                 .sorted { $0.targetName < $1.targetName }
                 .map { "import \($0.targetName)" })

--- a/Tools/Tests/BagbutikGeneratorTests/GeneratorTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/GeneratorTests.swift
@@ -153,7 +153,7 @@ final class GeneratorTests: XCTestCase {
             as: UTF8.self
         )
         XCTAssertTrue(usersResponse.contains("import BagbutikCore"))
-        XCTAssertTrue(usersResponse.contains("import BagbutikModelsShared"))
+        XCTAssertFalse(usersResponse.contains("import BagbutikModelsShared"))
         XCTAssertFalse(usersResponse.contains("import Bagbutik_Models"))
         let listUsers = String(
             decoding: fileManager.filesCreated.first { $0.name == "ListUsersV1.swift" }!.data,
@@ -169,7 +169,7 @@ final class GeneratorTests: XCTestCase {
         )
         XCTAssertFalse(linkageResponse.contains("import BagbutikUsersModels"))
         XCTAssertTrue(linkageResponse.contains("import BagbutikCore"))
-        XCTAssertTrue(linkageResponse.contains("import BagbutikModelsShared"))
+        XCTAssertFalse(linkageResponse.contains("import BagbutikModelsShared"))
         XCTAssertFalse(linkageResponse.contains("import Bagbutik_Core"))
     }
 
@@ -401,6 +401,24 @@ final class GeneratorTests: XCTestCase {
         XCTAssertTrue(requestModel.contents.contains("import Bagbutik_Core"))
         XCTAssertTrue(requestModel.contents.contains("import Bagbutik_Models"))
         XCTAssertTrue(linkageModel.contents.contains("import Bagbutik_Core"))
+    }
+
+    func testGenerateModelImportsOnlyItsReferencedModelModules() async throws {
+        let docsLoader = DocsLoader(schemaDocumentationById: [:])
+        let schema = Schema.object(.init(name: "GameCenterDetail", url: "some://url"))
+
+        let model = try await Generator.generateModel(
+            for: schema,
+            packageName: .gameCenter,
+            modelModule: .domainModels(.gameCenter),
+            referencedModelModules: [.domainModels(.appStore)],
+            otherSchemas: [:],
+            docsLoader: docsLoader
+        )
+
+        XCTAssertTrue(model.contents.contains("import BagbutikAppStoreModels"))
+        XCTAssertTrue(model.contents.contains("import BagbutikCore"))
+        XCTAssertFalse(model.contents.contains("import BagbutikModelsShared"))
     }
 
     func testConvenienceInitWithEmptySpecOnDisk() async throws {


### PR DESCRIPTION
## Summary

* Generate model imports from each schema's direct references instead of importing every dependency of the containing model target.
* Keep `BagbutikCore` as the foundational import for generated model files.
* Regenerate all currently migrated model modules.

## Root cause

The generator passed the complete target dependency set to every generated model file. As a result, a simple linkage response such as `AppGameCenterDetailLinkageResponse` imported App Store and shared model modules even though it only uses Core types.

The model target dependencies remain unchanged. They are still required for other files that genuinely reference cross domain model types. This change limits imports within each source file to its direct schema references.

## Impact

Generated source more accurately communicates model ownership and avoids unnecessary module imports. It does not change the public API, target dependency graph, or static binary contents.

## Validation

* Focused generator and runtime module plan tests pass.
* The complete source package builds for macOS.
* The focused Game Center integration tests pass.
* The generated source diff contains import changes only.
