### PR TITLE
Remove self import from users model extension

### DIFF
--- a/Sources/BagbutikUsersModels/Extensions/UserRole+PrettyName.swift
+++ b/Sources/BagbutikUsersModels/Extensions/UserRole+PrettyName.swift
@@ -1,5 +1,3 @@
-import BagbutikUsersModels
-
 public extension UserRole {
     /// A pretty name for the case. The names are added as best effort, and a better name could exist.
     var prettyName: String {


### PR DESCRIPTION
## Summary
- remove the self import from the manually maintained UserRole extension
- keep the generated source stable after regeneration

## Validation
- ran the bagbutik-cli generate command against the checked in OpenAPI spec
- confirmed only this intended source change remains
- ran swift test --disable-sandbox
- ran swift test --package-path Tools --disable-sandbox