### PR TITLE
Remove legacy generator fallback

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Bagbutik-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Bagbutik-Package.xcscheme
@@ -42,9 +42,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Bagbutik-CoreTests"
-               BuildableName = "Bagbutik-CoreTests"
-               BlueprintName = "Bagbutik-CoreTests"
+               BlueprintIdentifier = "BagbutikCoreTests"
+               BuildableName = "BagbutikCoreTests"
+               BlueprintName = "BagbutikCoreTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -447,9 +447,9 @@
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Bagbutik-CoreTests"
-               BuildableName = "Bagbutik-CoreTests"
-               BlueprintName = "Bagbutik-CoreTests"
+               BlueprintIdentifier = "BagbutikCoreTests"
+               BuildableName = "BagbutikCoreTests"
+               BlueprintName = "BagbutikCoreTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/Package.swift
+++ b/Package.swift
@@ -246,7 +246,7 @@ let package = Package(
         .target(name: "system-zlib"),
         // Test targets
         .testTarget(
-            name: "Bagbutik-CoreTests",
+            name: "BagbutikCoreTests",
             dependencies: [
                 "BagbutikCore",
                 "BagbutikAppStore",
@@ -254,6 +254,7 @@ let package = Package(
                 "BagbutikModelsShared",
                 .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux, .android]))
             ],
+            path: "Tests/Bagbutik-CoreTests",
             resources: [.copy("test-private-key.p8")]
         ),
         .testTarget(name: "BagbutikUmbrellaIntegrationTests", dependencies: ["Bagbutik"]),

--- a/Tools/Sources/BagbutikGenerator/FeedbackChecker.swift
+++ b/Tools/Sources/BagbutikGenerator/FeedbackChecker.swift
@@ -85,8 +85,21 @@ public class FeedbackChecker {
                 print("⚠️ Could not locate unpatched schema '\(patchedSchema.displayName)' from path metadata. Skipping direct comparison.")
                 continue
             }
-            let unpatchedModel = try await Generator.generateModel(for: unpatchedSchema, packageName: packageName, otherSchemas: originalSpec.components.schemas, docsLoader: self.docsLoader)
-            let patchedModel = try await Generator.generateModel(for: schema, packageName: packageName, otherSchemas: patchedSpec.components.schemas, docsLoader: self.docsLoader)
+            let modelModule: RuntimeModulePlan.ModelModule = packageName == .core
+                ? .core
+                : .domainModels(packageName)
+            let unpatchedModel = try await Generator.generateModel(
+                for: unpatchedSchema,
+                modelModule: modelModule,
+                otherSchemas: originalSpec.components.schemas,
+                docsLoader: self.docsLoader
+            )
+            let patchedModel = try await Generator.generateModel(
+                for: schema,
+                modelModule: modelModule,
+                otherSchemas: patchedSpec.components.schemas,
+                docsLoader: self.docsLoader
+            )
             if unpatchedModel == patchedModel {
                 schemasNotNeedingPatching.append(patchedSchema.displayName)
             } else {

--- a/Tools/Sources/BagbutikGenerator/Generator.swift
+++ b/Tools/Sources/BagbutikGenerator/Generator.swift
@@ -124,10 +124,6 @@ public class Generator {
             additionalRootsByPackage: endpointRootsByPackage
         )
 
-        let generalModelsDirURL = outputDirURL.appendingPathComponent("Bagbutik-Models")
-        for linkageModelsDirectory in ["LinkageRequests", "LinkageResponses"] {
-            try removeChildren(at: generalModelsDirURL.appendingPathComponent(linkageModelsDirectory))
-        }
         for packageName in PackageName.allCases {
             let packageDirURL = outputDirURL.appendingPathComponent(packageName.name)
             if packageName != .core {
@@ -141,9 +137,6 @@ public class Generator {
                 try removeChildren(at: modelsDirURL)
                 try fileManager.createDirectory(at: modelsDirURL, withIntermediateDirectories: true, attributes: nil)
             }
-
-            try removeChildren(at: generalModelsDirURL.appendingPathComponent(packageName.docsSectionName))
-            try fileManager.createDirectory(at: generalModelsDirURL, withIntermediateDirectories: true, attributes: nil)
         }
         let generatedModelsDirectories = [RuntimeModulePlan.ModelModule.modelsShared.targetName]
             + Self.migratedPackages
@@ -168,10 +161,9 @@ public class Generator {
                         if Self.migratedPackages.contains(packageName) {
                             let domainModelModule = RuntimeModulePlan.ModelModule.domainModels(packageName)
                             renderedOperation = renderedOperation
-                                .replacingOccurrences(of: "import Bagbutik_Core", with: "import BagbutikCore")
                                 .replacingOccurrences(
-                                    of: "import Bagbutik_Models",
-                                    with: Self.endpointModelImports(
+                                    of: "import BagbutikCore",
+                                    with: "import BagbutikCore\n" + Self.endpointModelImports(
                                         for: operation,
                                         domainModelModule: domainModelModule,
                                         modulePlan: modulePlan
@@ -202,12 +194,11 @@ public class Generator {
                 taskGroup.addTask { [docsLoader, schemas, packageBySchema, schemaReferenceGraph, modulePlan] in
                     let packageName = packageBySchema[schema.name]!
                     let modelModule = modulePlan[schema.name]
-                    guard modelModule != .legacyModels else { return nil }
+                    guard modelModule != .unassigned else { return nil }
                     let referencedModelModules = Set(schemaReferenceGraph.references[schema.name, default: []]
                         .map { modulePlan[$0] })
                     let model = try await Generator.generateModel(
                         for: schema,
-                        packageName: packageName,
                         modelModule: modelModule,
                         referencedModelModules: referencedModelModules,
                         otherSchemas: schemas,
@@ -215,24 +206,13 @@ public class Generator {
                     )
                     let fileName = model.name + ".swift"
 
-                    let modelsDirURL: URL = if modelModule.isGeneratedModelModule {
+                    let modelsDirURL: URL = switch modelModule {
+                    case .modelsShared, .domainModels:
                         outputDirURL.appendingPathComponent(modelModule.targetName)
-                    } else if schema.name.hasSuffix("LinkagesRequest") || schema.name.hasSuffix("LinkageRequest") {
-                        outputDirURL
-                            .appendingPathComponent("Bagbutik-Models")
-                            .appendingPathComponent("LinkageRequests")
-                    } else if schema.name.hasSuffix("LinkagesResponse") || schema.name.hasSuffix("LinkageResponse") {
-                        outputDirURL
-                            .appendingPathComponent("Bagbutik-Models")
-                            .appendingPathComponent("LinkageResponses")
-                    } else if packageName == .core || schema.name.hasSuffix("Request") || schema.name.hasSuffix("Response") {
-                        outputDirURL
-                            .appendingPathComponent(packageName.name)
-                            .appendingPathComponent("Models")
-                    } else {
-                        outputDirURL
-                            .appendingPathComponent("Bagbutik-Models")
-                            .appendingPathComponent(packageName.docsSectionName)
+                    case .core:
+                        outputDirURL.appendingPathComponent("Bagbutik-Core").appendingPathComponent("Models")
+                    case .unassigned:
+                        fatalError("Unassigned models are not rendered")
                     }
                     return .init(dirURL: modelsDirURL, name: model.name, fileName: fileName, contents: model.contents)
                 }
@@ -343,7 +323,7 @@ public class Generator {
         modulePlan: RuntimeModulePlan
     ) -> String {
         var directlyReferencedModules = Set(endpointSchemaNames(for: operation).map { modulePlan[$0] })
-            .subtracting([.core, .legacyModels, domainModelModule])
+            .subtracting([.core, .unassigned, domainModelModule])
         directlyReferencedModules.insert(domainModelModule)
         return directlyReferencedModules
             .map(\.targetName)
@@ -364,8 +344,7 @@ public class Generator {
      */
     static func generateModel(
         for schema: Schema,
-        packageName: PackageName,
-        modelModule: RuntimeModulePlan.ModelModule? = nil,
+        modelModule: RuntimeModulePlan.ModelModule,
         referencedModelModules: Set<RuntimeModulePlan.ModelModule>? = nil,
         otherSchemas: [String: Schema],
         docsLoader: DocsLoader
@@ -390,29 +369,21 @@ public class Generator {
         case .modelsShared:
             let dependencies = (referencedModelModules ?? [])
                 .union([.core])
-                .subtracting([.modelsShared, .legacyModels])
+                .subtracting([.modelsShared, .unassigned])
             imports.append(contentsOf: dependencies
                 .sorted { $0.targetName < $1.targetName }
                 .map { "import \($0.targetName)" })
         case let .domainModels(package):
             let dependencies = (referencedModelModules ?? [])
                 .union([.core])
-                .subtracting([.domainModels(package), .legacyModels])
+                .subtracting([.domainModels(package), .unassigned])
             imports.append(contentsOf: dependencies
                 .sorted { $0.targetName < $1.targetName }
                 .map { "import \($0.targetName)" })
         case .core:
             break
-        case .legacyModels, nil:
-            if packageName != .core {
-                imports.append("import Bagbutik_Core")
-                if schema.name.hasSuffix("Request") || schema.name.hasSuffix("Response") {
-                    imports.append("import Bagbutik_Models")
-                }
-            } else if schema.name.hasSuffix("LinkagesRequest") || schema.name.hasSuffix("LinkageRequest")
-                || schema.name.hasSuffix("LinkagesResponse") || schema.name.hasSuffix("LinkageResponse") {
-                imports.append("import Bagbutik_Core")
-            }
+        case .unassigned:
+            break
         }
         let contents = """
         \(imports.sorted().joined(separator: "\n"))

--- a/Tools/Sources/BagbutikGenerator/Renderers/OperationRenderer.swift
+++ b/Tools/Sources/BagbutikGenerator/Renderers/OperationRenderer.swift
@@ -40,7 +40,7 @@ public class OperationRenderer: Renderer {
             withTemplate: #"\\($1)"#)
         let parametersInfo = try await OperationParametersInfo(for: operation, in: path, docsLoader: docsLoader)
         let operationName = operation.getVersionedName(path: path)
-        var rendered = await "import Bagbutik_Core\nimport Bagbutik_Models\n\n" + renderExtension(on: "Request") {
+        var rendered = await "import BagbutikCore\n\n" + renderExtension(on: "Request") {
             let title = documentation?.title ?? "No overview available"
             var parameters = parametersInfo.pathParameters
             if let requestBody = parametersInfo.requestBody {

--- a/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
+++ b/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
@@ -8,21 +8,21 @@ public struct RuntimeModulePlan: Sendable {
         case core
         case modelsShared
         case domainModels(PackageName)
-        case legacyModels
+        case unassigned
 
         public var targetName: String {
             switch self {
             case .core: "BagbutikCore"
             case .modelsShared: "BagbutikModelsShared"
             case .domainModels(let package): "Bagbutik\(package.docsSectionName)Models"
-            case .legacyModels: "Bagbutik-Models"
+            case .unassigned: ""
             }
         }
 
         public var isGeneratedModelModule: Bool {
             switch self {
             case .modelsShared, .domainModels: true
-            case .core, .legacyModels: false
+            case .core, .unassigned: false
             }
         }
     }
@@ -65,16 +65,16 @@ public struct RuntimeModulePlan: Sendable {
                     result[schema] = .modelsShared
                 }
             } else {
-                result[schema] = .legacyModels
+                result[schema] = .unassigned
             }
         }
 
         for component in graph.stronglyConnectedComponents() {
             let modules = Set(component.schemas.compactMap { assignments[$0] })
-                .subtracting([.legacyModels])
+                .subtracting([.unassigned])
             guard modules.count > 1 else { continue }
             let collapsedModule: ModelModule = modules.contains(.core) ? .core : .modelsShared
-            for schema in component.schemas where assignments[schema] != .legacyModels {
+            for schema in component.schemas where assignments[schema] != .unassigned {
                 assignments[schema] = collapsedModule
             }
         }
@@ -99,11 +99,11 @@ public struct RuntimeModulePlan: Sendable {
             dependencies[.domainModels(package), default: []].formUnion([.core, .modelsShared])
         }
         for (schema, references) in graph.references {
-            guard let sourceModule = assignments[schema], sourceModule != .legacyModels else { continue }
+            guard let sourceModule = assignments[schema], sourceModule != .unassigned else { continue }
             for reference in references {
                 guard let dependencyModule = assignments[reference],
                       dependencyModule != sourceModule,
-                      dependencyModule != .legacyModels else { continue }
+                      dependencyModule != .unassigned else { continue }
                 dependencies[sourceModule, default: []].insert(dependencyModule)
             }
         }
@@ -111,7 +111,7 @@ public struct RuntimeModulePlan: Sendable {
     }
 
     public subscript(schemaName: String) -> ModelModule {
-        moduleBySchema[schemaName, default: .legacyModels]
+        moduleBySchema[schemaName, default: .unassigned]
     }
 
     public func dependencies(for module: ModelModule) -> Set<ModelModule> {

--- a/Tools/Tests/BagbutikGeneratorTests/GeneratorTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/GeneratorTests.swift
@@ -57,39 +57,17 @@ final class GeneratorTests: XCTestCase {
         // Then
         continueAfterFailure = false
         XCTAssertEqual(fileManager.itemsRemoved, [
-            "/Users/steve/output/Bagbutik-Models/LinkageRequests",
-            "/Users/steve/output/Bagbutik-Models/LinkageResponses",
             "/Users/steve/output/Bagbutik-AppStore",
-            "/Users/steve/output/Bagbutik-Models/AppStore",
             "/Users/steve/output/Bagbutik-Core/Endpoints",
             "/Users/steve/output/Bagbutik-Core/Models",
-            "/Users/steve/output/Bagbutik-Models/Core",
             "/Users/steve/output/Bagbutik-GameCenter",
-            "/Users/steve/output/Bagbutik-Models/GameCenter",
             "/Users/steve/output/Bagbutik-Marketplaces",
-            "/Users/steve/output/Bagbutik-Models/Marketplaces",
             "/Users/steve/output/Bagbutik-Provisioning",
-            "/Users/steve/output/Bagbutik-Models/Provisioning",
             "/Users/steve/output/Bagbutik-Reporting",
-            "/Users/steve/output/Bagbutik-Models/Reporting",
             "/Users/steve/output/Bagbutik-TestFlight",
-            "/Users/steve/output/Bagbutik-Models/TestFlight",
             "/Users/steve/output/Bagbutik-Users",
-            "/Users/steve/output/Bagbutik-Models/Users",
             "/Users/steve/output/Bagbutik-Webhooks",
-            "/Users/steve/output/Bagbutik-Models/Webhooks",
             "/Users/steve/output/Bagbutik-XcodeCloud",
-            "/Users/steve/output/Bagbutik-Models/XcodeCloud",
-            "/Users/steve/output/BagbutikModelsShared",
-            "/Users/steve/output/BagbutikAppStoreModels",
-            "/Users/steve/output/BagbutikGameCenterModels",
-            "/Users/steve/output/BagbutikMarketplacesModels",
-            "/Users/steve/output/BagbutikProvisioningModels",
-            "/Users/steve/output/BagbutikReportingModels",
-            "/Users/steve/output/BagbutikTestFlightModels",
-            "/Users/steve/output/BagbutikUsersModels",
-            "/Users/steve/output/BagbutikWebhooksModels",
-            "/Users/steve/output/BagbutikXcodeCloudModels",
         ])
         XCTAssertEqual(Set(fileManager.directoriesCreated).sorted(), [
             "/Users/steve/output/Bagbutik-AppStore",
@@ -97,7 +75,6 @@ final class GeneratorTests: XCTestCase {
             "/Users/steve/output/Bagbutik-Core/Models",
             "/Users/steve/output/Bagbutik-GameCenter",
             "/Users/steve/output/Bagbutik-Marketplaces",
-            "/Users/steve/output/Bagbutik-Models",
             "/Users/steve/output/Bagbutik-Provisioning",
             "/Users/steve/output/Bagbutik-Reporting",
             "/Users/steve/output/Bagbutik-TestFlight",
@@ -395,12 +372,21 @@ final class GeneratorTests: XCTestCase {
         let requestSchema = Schema.object(.init(name: "UserUpdateRequest", url: "some://url"))
         let linkageSchema = Schema.object(.init(name: "UserVisibleAppsLinkageResponse", url: "some://url"))
 
-        let requestModel = try await Generator.generateModel(for: requestSchema, packageName: .users, otherSchemas: [:], docsLoader: docsLoader)
-        let linkageModel = try await Generator.generateModel(for: linkageSchema, packageName: .core, otherSchemas: [:], docsLoader: docsLoader)
+        let requestModel = try await Generator.generateModel(
+            for: requestSchema,
+            modelModule: .domainModels(.users),
+            otherSchemas: [:],
+            docsLoader: docsLoader
+        )
+        let linkageModel = try await Generator.generateModel(
+            for: linkageSchema,
+            modelModule: .core,
+            otherSchemas: [:],
+            docsLoader: docsLoader
+        )
 
-        XCTAssertTrue(requestModel.contents.contains("import Bagbutik_Core"))
-        XCTAssertTrue(requestModel.contents.contains("import Bagbutik_Models"))
-        XCTAssertTrue(linkageModel.contents.contains("import Bagbutik_Core"))
+        XCTAssertTrue(requestModel.contents.contains("import BagbutikCore"))
+        XCTAssertFalse(linkageModel.contents.contains("import Bagbutik_"))
     }
 
     func testGenerateModelImportsOnlyItsReferencedModelModules() async throws {
@@ -409,7 +395,6 @@ final class GeneratorTests: XCTestCase {
 
         let model = try await Generator.generateModel(
             for: schema,
-            packageName: .gameCenter,
             modelModule: .domainModels(.gameCenter),
             referencedModelModules: [.domainModels(.appStore)],
             otherSchemas: [:],

--- a/Tools/Tests/BagbutikGeneratorTests/Renderers/OperationRendererTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/Renderers/OperationRendererTests.swift
@@ -23,8 +23,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**
@@ -67,8 +66,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**
@@ -130,8 +128,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**
@@ -202,8 +199,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**
@@ -238,8 +234,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**
@@ -288,8 +283,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**
@@ -491,8 +485,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**
@@ -588,8 +581,7 @@ final class OperationRendererTests: XCTestCase {
         let rendered = try await renderer.render(operation: operation, in: path)
         // Then
         XCTAssertEqual(rendered, #"""
-        import Bagbutik_Core
-        import Bagbutik_Models
+        import BagbutikCore
 
         public extension Request {
             /**

--- a/Tools/Tests/BagbutikGeneratorTests/RuntimeModulePlanTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/RuntimeModulePlanTests.swift
@@ -40,7 +40,7 @@ final class RuntimeModulePlanTests: XCTestCase {
         XCTAssertEqual(plan["SubscriptionStatusUrlVersion"], .modelsShared)
         XCTAssertEqual(plan["User"], .domainModels(.users))
         XCTAssertEqual(plan["UsersResponse"], .domainModels(.users))
-        XCTAssertEqual(plan["Build"], .legacyModels)
+        XCTAssertEqual(plan["Build"], .unassigned)
     }
 
     func testCrossDomainCycleIsKeptInOneSharedModule() {
@@ -178,7 +178,7 @@ final class RuntimeModulePlanTests: XCTestCase {
         XCTAssertEqual(plan["CustomerReview"], .domainModels(.appStore))
         XCTAssertEqual(plan["Territory"], .domainModels(.appStore))
         XCTAssertEqual(plan["UnrelatedAppClip"], .domainModels(.appStore))
-        XCTAssertEqual(plan["UnrelatedGameCenterActivity"], .legacyModels)
+        XCTAssertEqual(plan["UnrelatedGameCenterActivity"], .unassigned)
         XCTAssertEqual(
             plan.dependencies(for: .domainModels(.appStore)),
             [.core, .modelsShared]


### PR DESCRIPTION
## Summary

- Rename the Bagbutik core test target to `BagbutikCoreTests`.
- Remove the generator fallback that emitted the old `Bagbutik-Models` layout and `Bagbutik_*` imports.
- Make model rendering require an explicit modern runtime module.
- Keep unassigned schemas out of generated output without assigning them to a legacy module.
- Update generator, feedback checker, runtime plan, and renderer tests.

## Validation

- Ran the generator with `swift run --disable-sandbox --package-path Tools bagbutik-cli generate ...`; generated source files had no drift.
- `swift test --package-path Tools --disable-sandbox` passed: 226 tests.
- `swift test --disable-sandbox` passed: 93 tests.
- `git diff --check` passed.

This should merge into `v24/architecture` before the architecture branch is reconsidered for `main`.