### PR TITLE
Remove unassigned model module

### DIFF
--- a/Sources/BagbutikAppStore/Endpoints/AccessibilityDeclaration/DeleteAccessibilityDeclarationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AccessibilityDeclaration/DeleteAccessibilityDeclarationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Actor/ListActorsV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Actor/ListActorsV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AndroidToIosAppMappingDetail/DeleteAndroidToIosAppMappingDetailV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AndroidToIosAppMappingDetail/DeleteAndroidToIosAppMappingDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/ListAppsV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/ListAppsV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppClipsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppClipsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppCustomProductPagesForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppCustomProductPagesForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppEncryptionDeclarationsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppEncryptionDeclarationsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppEventsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppEventsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppPricePointsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppPricePointsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppStoreVersionsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppStoreVersionsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppTagsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListAppTagsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListBackgroundAssetsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListBackgroundAssetsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListBuildUploadsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListBuildUploadsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListCustomerReviewSummarizationsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListCustomerReviewSummarizationsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListInAppPurchasesForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListInAppPurchasesForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListInAppPurchasesV2ForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListInAppPurchasesV2ForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListSearchKeywordsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListSearchKeywordsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListSubscriptionGroupsForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ListSubscriptionGroupsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/App/Relationships/ReplacePromotedPurchasesForAppV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/App/Relationships/ReplacePromotedPurchasesForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCategory/ListAppCategoriesV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCategory/ListAppCategoriesV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppClip/Relationships/ListAppClipDefaultExperiencesForAppClipV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppClip/Relationships/ListAppClipDefaultExperiencesForAppClipV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperience/DeleteAppClipDefaultExperienceV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperience/DeleteAppClipDefaultExperienceV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperience/Relationships/ListAppClipDefaultExperienceLocalizationsForAppClipDefaultExperienceV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperience/Relationships/ListAppClipDefaultExperienceLocalizationsForAppClipDefaultExperienceV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperience/Relationships/UpdateReleaseWithAppStoreVersionForAppClipDefaultExperienceV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperience/Relationships/UpdateReleaseWithAppStoreVersionForAppClipDefaultExperienceV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperienceLocalization/DeleteAppClipDefaultExperienceLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppClipDefaultExperienceLocalization/DeleteAppClipDefaultExperienceLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppClipHeaderImage/DeleteAppClipHeaderImageV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppClipHeaderImage/DeleteAppClipHeaderImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPage/DeleteAppCustomProductPageV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPage/DeleteAppCustomProductPageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/DeleteAppCustomProductPageLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/DeleteAppCustomProductPageLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/CreateSearchKeywordsForAppCustomProductPageLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/CreateSearchKeywordsForAppCustomProductPageLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/DeleteSearchKeywordsForAppCustomProductPageLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/DeleteSearchKeywordsForAppCustomProductPageLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/ListAppPreviewSetsForAppCustomProductPageLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/ListAppPreviewSetsForAppCustomProductPageLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/ListAppScreenshotSetsForAppCustomProductPageLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/ListAppScreenshotSetsForAppCustomProductPageLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/ListSearchKeywordsForAppCustomProductPageLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageLocalization/Relationships/ListSearchKeywordsForAppCustomProductPageLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageVersion/Relationships/ListAppCustomProductPageLocalizationsForAppCustomProductPageVersionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppCustomProductPageVersion/Relationships/ListAppCustomProductPageLocalizationsForAppCustomProductPageVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppEncryptionDeclaration/ListAppEncryptionDeclarationsV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppEncryptionDeclaration/ListAppEncryptionDeclarationsV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppEncryptionDeclaration/Relationships/CreateBuildsForAppEncryptionDeclarationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppEncryptionDeclaration/Relationships/CreateBuildsForAppEncryptionDeclarationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppEvent/DeleteAppEventV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppEvent/DeleteAppEventV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppEventLocalization/DeleteAppEventLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppEventLocalization/DeleteAppEventLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppEventScreenshot/DeleteAppEventScreenshotV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppEventScreenshot/DeleteAppEventScreenshotV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppEventVideoClip/DeleteAppEventVideoClipV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppEventVideoClip/DeleteAppEventVideoClipV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppInfo/Relationships/ListAppInfoLocalizationsForAppInfoV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppInfo/Relationships/ListAppInfoLocalizationsForAppInfoV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppInfoLocalization/DeleteAppInfoLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppInfoLocalization/DeleteAppInfoLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppPreview/DeleteAppPreviewV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppPreview/DeleteAppPreviewV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppPreviewSet/DeleteAppPreviewSetV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppPreviewSet/DeleteAppPreviewSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppPreviewSet/Relationships/ReplaceAppPreviewsForAppPreviewSetV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppPreviewSet/Relationships/ReplaceAppPreviewsForAppPreviewSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppPricePoint/Relationships/ListEqualizationsForAppPricePointsV3.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppPricePoint/Relationships/ListEqualizationsForAppPricePointsV3.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppPriceSchedule/Relationships/ListAutomaticPricesForAppPriceScheduleV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppPriceSchedule/Relationships/ListAutomaticPricesForAppPriceScheduleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppPriceSchedule/Relationships/ListManualPricesForAppPriceScheduleV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppPriceSchedule/Relationships/ListManualPricesForAppPriceScheduleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppScreenshot/DeleteAppScreenshotV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppScreenshot/DeleteAppScreenshotV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppScreenshotSet/DeleteAppScreenshotSetV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppScreenshotSet/DeleteAppScreenshotSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppScreenshotSet/Relationships/ReplaceAppScreenshotsForAppScreenshotSetV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppScreenshotSet/Relationships/ReplaceAppScreenshotsForAppScreenshotSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreReviewAttachment/DeleteAppStoreReviewAttachmentV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreReviewAttachment/DeleteAppStoreReviewAttachmentV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/DeleteAppStoreVersionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/DeleteAppStoreVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/Relationships/ListAppStoreVersionLocalizationsForAppStoreVersionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/Relationships/ListAppStoreVersionLocalizationsForAppStoreVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/Relationships/UpdateAppClipDefaultExperienceForAppStoreVersionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/Relationships/UpdateAppClipDefaultExperienceForAppStoreVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/Relationships/UpdateBuildForAppStoreVersionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersion/Relationships/UpdateBuildForAppStoreVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperiment/DeleteAppStoreVersionExperimentV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperiment/DeleteAppStoreVersionExperimentV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperiment/DeleteAppStoreVersionExperimentsV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperiment/DeleteAppStoreVersionExperimentsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatment/DeleteAppStoreVersionExperimentTreatmentV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatment/DeleteAppStoreVersionExperimentTreatmentV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatment/Relationships/ListAppStoreVersionExperimentTreatmentLocalizationsForAppStoreVersionExperimentTreatmentV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatment/Relationships/ListAppStoreVersionExperimentTreatmentLocalizationsForAppStoreVersionExperimentTreatmentV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatmentLocalization/DeleteAppStoreVersionExperimentTreatmentLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatmentLocalization/DeleteAppStoreVersionExperimentTreatmentLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatmentLocalization/Relationships/ListAppPreviewSetsForAppStoreVersionExperimentTreatmentLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatmentLocalization/Relationships/ListAppPreviewSetsForAppStoreVersionExperimentTreatmentLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatmentLocalization/Relationships/ListAppScreenshotSetsForAppStoreVersionExperimentTreatmentLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionExperimentTreatmentLocalization/Relationships/ListAppScreenshotSetsForAppStoreVersionExperimentTreatmentLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/DeleteAppStoreVersionLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/DeleteAppStoreVersionLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/CreateSearchKeywordsForAppStoreVersionLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/CreateSearchKeywordsForAppStoreVersionLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/DeleteSearchKeywordsForAppStoreVersionLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/DeleteSearchKeywordsForAppStoreVersionLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/ListAppPreviewSetsForAppStoreVersionLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/ListAppPreviewSetsForAppStoreVersionLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/ListAppScreenshotSetsForAppStoreVersionLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/ListAppScreenshotSetsForAppStoreVersionLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/ListSearchKeywordsForAppStoreVersionLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionLocalization/Relationships/ListSearchKeywordsForAppStoreVersionLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionPhasedRelease/DeleteAppStoreVersionPhasedReleaseV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionPhasedRelease/DeleteAppStoreVersionPhasedReleaseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/AppStoreVersionSubmission/DeleteAppStoreVersionSubmissionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/AppStoreVersionSubmission/DeleteAppStoreVersionSubmissionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/BackgroundAsset/Relationships/ListVersionsForBackgroundAssetV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/BackgroundAsset/Relationships/ListVersionsForBackgroundAssetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/BetaGroup/Relationships/CreateBuildsForBetaGroupV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/BetaGroup/Relationships/CreateBuildsForBetaGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/BetaGroup/Relationships/DeleteBuildsForBetaGroupV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/BetaGroup/Relationships/DeleteBuildsForBetaGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/BetaTester/Relationships/CreateBuildsForBetaTesterV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/BetaTester/Relationships/CreateBuildsForBetaTesterV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/BetaTester/Relationships/DeleteAppsForBetaTesterV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/BetaTester/Relationships/DeleteAppsForBetaTesterV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/BetaTester/Relationships/DeleteBuildsForBetaTesterV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/BetaTester/Relationships/DeleteBuildsForBetaTesterV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/BuildUpload/DeleteBuildUploadV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/BuildUpload/DeleteBuildUploadV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/CustomerReviewResponse/DeleteCustomerReviewResponseV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/CustomerReviewResponse/DeleteCustomerReviewResponseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/EndUserLicenseAgreement/DeleteEndUserLicenseAgreementV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/EndUserLicenseAgreement/DeleteEndUserLicenseAgreementV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchase/DeleteInAppPurchasesV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchase/DeleteInAppPurchasesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchase/Relationships/ListOfferCodesForInAppPurchasesV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchase/Relationships/ListOfferCodesForInAppPurchasesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchase/Relationships/ListPricePointsForInAppPurchasesV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchase/Relationships/ListPricePointsForInAppPurchasesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchaseAppStoreReviewScreenshot/DeleteInAppPurchaseAppStoreReviewScreenshotV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchaseAppStoreReviewScreenshot/DeleteInAppPurchaseAppStoreReviewScreenshotV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchaseImage/DeleteInAppPurchaseImageV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchaseImage/DeleteInAppPurchaseImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchaseImage/DeleteInAppPurchaseImagesV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchaseImage/DeleteInAppPurchaseImagesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchaseLocalization/DeleteInAppPurchaseLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchaseLocalization/DeleteInAppPurchaseLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchaseLocalization/DeleteInAppPurchaseLocalizationsV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchaseLocalization/DeleteInAppPurchaseLocalizationsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchaseOfferCode/Relationships/ListPricesForInAppPurchaseOfferCodeV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchaseOfferCode/Relationships/ListPricesForInAppPurchaseOfferCodeV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchasePricePoint/Relationships/ListEqualizationsForInAppPurchasePricePointV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchasePricePoint/Relationships/ListEqualizationsForInAppPurchasePricePointV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchasePriceSchedule/Relationships/ListAutomaticPricesForInAppPurchasePriceScheduleV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchasePriceSchedule/Relationships/ListAutomaticPricesForInAppPurchasePriceScheduleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/InAppPurchasePriceSchedule/Relationships/ListManualPricesForInAppPurchasePriceScheduleV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/InAppPurchasePriceSchedule/Relationships/ListManualPricesForInAppPurchasePriceScheduleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Nomination/DeleteNominationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Nomination/DeleteNominationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Nomination/ListNominationsV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Nomination/ListNominationsV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/PromotedPurchase/DeletePromotedPurchaseV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/PromotedPurchase/DeletePromotedPurchaseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/ReviewSubmission/ListReviewSubmissionsV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/ReviewSubmission/ListReviewSubmissionsV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/ReviewSubmissionItem/DeleteReviewSubmissionItemV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/ReviewSubmissionItem/DeleteReviewSubmissionItemV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/RoutingAppCoverage/DeleteRoutingAppCoverageV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/RoutingAppCoverage/DeleteRoutingAppCoverageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/DeleteSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/DeleteSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/DeleteIntroductoryOffersForSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/DeleteIntroductoryOffersForSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/DeletePricesForSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/DeletePricesForSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListIntroductoryOffersForSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListIntroductoryOffersForSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListOfferCodesForSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListOfferCodesForSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListPricePointsForSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListPricePointsForSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListPricesForSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListPricesForSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListPromotionalOffersForSubscriptionV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Subscription/Relationships/ListPromotionalOffersForSubscriptionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionAppStoreReviewScreenshot/DeleteSubscriptionAppStoreReviewScreenshotV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionAppStoreReviewScreenshot/DeleteSubscriptionAppStoreReviewScreenshotV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionGroup/DeleteSubscriptionGroupV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionGroup/DeleteSubscriptionGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionGroup/Relationships/ListSubscriptionsForSubscriptionGroupV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionGroup/Relationships/ListSubscriptionsForSubscriptionGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionGroupLocalization/DeleteSubscriptionGroupLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionGroupLocalization/DeleteSubscriptionGroupLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionGroupLocalization/DeleteSubscriptionGroupLocalizationsV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionGroupLocalization/DeleteSubscriptionGroupLocalizationsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionImage/DeleteSubscriptionImageV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionImage/DeleteSubscriptionImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionImage/DeleteSubscriptionImagesV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionImage/DeleteSubscriptionImagesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionIntroductoryOffer/DeleteSubscriptionIntroductoryOfferV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionIntroductoryOffer/DeleteSubscriptionIntroductoryOfferV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionLocalization/DeleteSubscriptionLocalizationV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionLocalization/DeleteSubscriptionLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionLocalization/DeleteSubscriptionLocalizationsV2.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionLocalization/DeleteSubscriptionLocalizationsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionOfferCode/Relationships/ListPricesForSubscriptionOfferCodeV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionOfferCode/Relationships/ListPricesForSubscriptionOfferCodeV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionPlanAvailability/Relationships/ReplaceAvailableTerritoriesForSubscriptionPlanAvailabilityV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionPlanAvailability/Relationships/ReplaceAvailableTerritoriesForSubscriptionPlanAvailabilityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionPrice/DeleteSubscriptionPriceV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionPrice/DeleteSubscriptionPriceV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionPricePoint/Relationships/ListAdjustedEqualizationsForSubscriptionPricePointV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionPricePoint/Relationships/ListAdjustedEqualizationsForSubscriptionPricePointV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionPricePoint/Relationships/ListEqualizationsForSubscriptionPricePointV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionPricePoint/Relationships/ListEqualizationsForSubscriptionPricePointV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionPromotionalOffer/DeleteSubscriptionPromotionalOfferV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionPromotionalOffer/DeleteSubscriptionPromotionalOfferV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/SubscriptionPromotionalOffer/Relationships/ListPricesForSubscriptionPromotionalOfferV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/SubscriptionPromotionalOffer/Relationships/ListPricesForSubscriptionPromotionalOfferV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/User/Relationships/CreateVisibleAppsForUserV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/User/Relationships/CreateVisibleAppsForUserV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/User/Relationships/DeleteVisibleAppsForUserV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/User/Relationships/DeleteVisibleAppsForUserV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/User/Relationships/ReplaceVisibleAppsForUserV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/User/Relationships/ReplaceVisibleAppsForUserV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/WinBackOffer/DeleteWinBackOfferV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/WinBackOffer/DeleteWinBackOfferV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikAppStore/Endpoints/WinBackOffer/Relationships/ListPricesForWinBackOfferV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/WinBackOffer/Relationships/ListPricesForWinBackOfferV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikAppStoreModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/App/Relationships/ListGameCenterEnabledVersionsForAppV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/App/Relationships/ListGameCenterEnabledVersionsForAppV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/DeleteGameCenterAchievementV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/DeleteGameCenterAchievementV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/DeleteGameCenterAchievementsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/DeleteGameCenterAchievementsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/ListReleasesForGameCenterAchievementV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/ListReleasesForGameCenterAchievementV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/UpdateActivityForGameCenterAchievementV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/UpdateActivityForGameCenterAchievementV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/UpdateActivityForGameCenterAchievementsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/UpdateActivityForGameCenterAchievementsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/UpdateGroupAchievementForGameCenterAchievementV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievement/Relationships/UpdateGroupAchievementForGameCenterAchievementV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementImage/DeleteGameCenterAchievementImageV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementImage/DeleteGameCenterAchievementImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementImage/DeleteGameCenterAchievementImagesV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementImage/DeleteGameCenterAchievementImagesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementLocalization/DeleteGameCenterAchievementLocalizationV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementLocalization/DeleteGameCenterAchievementLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementLocalization/DeleteGameCenterAchievementLocalizationsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementLocalization/DeleteGameCenterAchievementLocalizationsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementRelease/DeleteGameCenterAchievementReleaseV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAchievementRelease/DeleteGameCenterAchievementReleaseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/DeleteGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/DeleteGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateAchievementsForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateAchievementsForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateAchievementsV2ForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateAchievementsV2ForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateLeaderboardsForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateLeaderboardsForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateLeaderboardsV2ForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/CreateLeaderboardsV2ForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteAchievementsForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteAchievementsForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteAchievementsV2ForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteAchievementsV2ForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteLeaderboardsForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteLeaderboardsForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteLeaderboardsV2ForGameCenterActivityV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivity/Relationships/DeleteLeaderboardsV2ForGameCenterActivityV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivityImage/DeleteGameCenterActivityImageV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivityImage/DeleteGameCenterActivityImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivityLocalization/DeleteGameCenterActivityLocalizationV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivityLocalization/DeleteGameCenterActivityLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterActivityVersionRelease/DeleteGameCenterActivityVersionReleaseV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterActivityVersionRelease/DeleteGameCenterActivityVersionReleaseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAppVersion/Relationships/CreateCompatibilityVersionsForGameCenterAppVersionV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAppVersion/Relationships/CreateCompatibilityVersionsForGameCenterAppVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAppVersion/Relationships/DeleteCompatibilityVersionsForGameCenterAppVersionV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAppVersion/Relationships/DeleteCompatibilityVersionsForGameCenterAppVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterAppVersion/Relationships/ListCompatibilityVersionsForGameCenterAppVersionV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterAppVersion/Relationships/ListCompatibilityVersionsForGameCenterAppVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterChallenge/DeleteGameCenterChallengeV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterChallenge/DeleteGameCenterChallengeV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterChallenge/Relationships/UpdateLeaderboardForGameCenterChallengeV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterChallenge/Relationships/UpdateLeaderboardForGameCenterChallengeV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterChallenge/Relationships/UpdateLeaderboardV2ForGameCenterChallengeV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterChallenge/Relationships/UpdateLeaderboardV2ForGameCenterChallengeV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterChallengeImage/DeleteGameCenterChallengeImageV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterChallengeImage/DeleteGameCenterChallengeImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterChallengeLocalization/DeleteGameCenterChallengeLocalizationV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterChallengeLocalization/DeleteGameCenterChallengeLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterChallengeVersionRelease/DeleteGameCenterChallengeVersionReleaseV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterChallengeVersionRelease/DeleteGameCenterChallengeVersionReleaseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListAchievementReleasesForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListAchievementReleasesForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterAchievementsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterAchievementsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterAchievementsV2ForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterAchievementsV2ForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterAppVersionsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterAppVersionsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterChallengesForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterChallengesForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardSetsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardSetsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardSetsV2ForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardSetsV2ForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardsV2ForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListGameCenterLeaderboardsV2ForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListLeaderboardReleasesForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListLeaderboardReleasesForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListLeaderboardSetReleasesForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ListLeaderboardSetReleasesForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceChallengesMinimumPlatformVersionsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceChallengesMinimumPlatformVersionsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterAchievementsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterAchievementsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterAchievementsV2ForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterAchievementsV2ForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardSetsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardSetsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardSetsV2ForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardSetsV2ForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardsForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardsForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardsV2ForGameCenterDetailV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterDetail/Relationships/ReplaceGameCenterLeaderboardsV2ForGameCenterDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/CreateCompatibleVersionsForGameCenterEnabledVersionV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/CreateCompatibleVersionsForGameCenterEnabledVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/DeleteCompatibleVersionsForGameCenterEnabledVersionV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/DeleteCompatibleVersionsForGameCenterEnabledVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/ListCompatibleVersionsForGameCenterEnabledVersionV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/ListCompatibleVersionsForGameCenterEnabledVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/ReplaceCompatibleVersionsForGameCenterEnabledVersionV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterEnabledVersion/Relationships/ReplaceCompatibleVersionsForGameCenterEnabledVersionV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/DeleteGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/DeleteGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/ListGameCenterGroupsV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/ListGameCenterGroupsV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterAchievementsForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterAchievementsForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterAchievementsV2ForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterAchievementsV2ForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterChallengesForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterChallengesForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterDetailsForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterDetailsForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardSetsForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardSetsForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardSetsV2ForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardSetsV2ForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardsForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardsForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardsV2ForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ListGameCenterLeaderboardsV2ForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterAchievementsForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterAchievementsForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterAchievementsV2ForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterAchievementsV2ForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardSetsForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardSetsForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardSetsV2ForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardSetsV2ForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardsForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardsForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardsV2ForGameCenterGroupV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterGroup/Relationships/ReplaceGameCenterLeaderboardsV2ForGameCenterGroupV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/DeleteGameCenterLeaderboardV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/DeleteGameCenterLeaderboardV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/DeleteGameCenterLeaderboardsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/DeleteGameCenterLeaderboardsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/ListReleasesForGameCenterLeaderboardV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/ListReleasesForGameCenterLeaderboardV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateActivityForGameCenterLeaderboardV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateActivityForGameCenterLeaderboardV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateActivityForGameCenterLeaderboardsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateActivityForGameCenterLeaderboardsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateChallengeForGameCenterLeaderboardV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateChallengeForGameCenterLeaderboardV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateChallengeForGameCenterLeaderboardsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateChallengeForGameCenterLeaderboardsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateGroupLeaderboardForGameCenterLeaderboardV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboard/Relationships/UpdateGroupLeaderboardForGameCenterLeaderboardV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardImage/DeleteGameCenterLeaderboardImageV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardImage/DeleteGameCenterLeaderboardImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardImage/DeleteGameCenterLeaderboardImagesV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardImage/DeleteGameCenterLeaderboardImagesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardLocalization/DeleteGameCenterLeaderboardLocalizationV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardLocalization/DeleteGameCenterLeaderboardLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardLocalization/DeleteGameCenterLeaderboardLocalizationsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardLocalization/DeleteGameCenterLeaderboardLocalizationsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardRelease/DeleteGameCenterLeaderboardReleaseV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardRelease/DeleteGameCenterLeaderboardReleaseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/DeleteGameCenterLeaderboardSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/DeleteGameCenterLeaderboardSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/DeleteGameCenterLeaderboardSetsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/DeleteGameCenterLeaderboardSetsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/CreateGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/CreateGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/CreateGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/CreateGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/DeleteGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/DeleteGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/DeleteGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/DeleteGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ListGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ListGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ListGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ListGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ListReleasesForGameCenterLeaderboardSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ListReleasesForGameCenterLeaderboardSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ReplaceGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ReplaceGameCenterLeaderboardsForGameCenterLeaderboardSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ReplaceGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/ReplaceGameCenterLeaderboardsForGameCenterLeaderboardSetsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/UpdateGroupLeaderboardSetForGameCenterLeaderboardSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSet/Relationships/UpdateGroupLeaderboardSetForGameCenterLeaderboardSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetImage/DeleteGameCenterLeaderboardSetImageV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetImage/DeleteGameCenterLeaderboardSetImageV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetImage/DeleteGameCenterLeaderboardSetImagesV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetImage/DeleteGameCenterLeaderboardSetImagesV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetLocalization/DeleteGameCenterLeaderboardSetLocalizationV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetLocalization/DeleteGameCenterLeaderboardSetLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetLocalization/DeleteGameCenterLeaderboardSetLocalizationsV2.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetLocalization/DeleteGameCenterLeaderboardSetLocalizationsV2.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetMemberLocalization/DeleteGameCenterLeaderboardSetMemberLocalizationV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetMemberLocalization/DeleteGameCenterLeaderboardSetMemberLocalizationV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetMemberLocalization/ListGameCenterLeaderboardSetMemberLocalizationsV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetMemberLocalization/ListGameCenterLeaderboardSetMemberLocalizationsV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetRelease/DeleteGameCenterLeaderboardSetReleaseV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterLeaderboardSetRelease/DeleteGameCenterLeaderboardSetReleaseV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingQueue/DeleteGameCenterMatchmakingQueueV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingQueue/DeleteGameCenterMatchmakingQueueV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingQueue/Relationships/GetMetricsForExperimentMatchmakingRequestInGameCenterMatchmakingQueueV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingQueue/Relationships/GetMetricsForExperimentMatchmakingRequestInGameCenterMatchmakingQueueV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingQueue/Relationships/GetMetricsForMatchmakingRequestInGameCenterMatchmakingQueueV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingQueue/Relationships/GetMetricsForMatchmakingRequestInGameCenterMatchmakingQueueV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/DeleteGameCenterMatchmakingRuleV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/DeleteGameCenterMatchmakingRuleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/Relationships/GetMetricsForMatchmakingBooleanRuleResultInGameCenterMatchmakingRuleV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/Relationships/GetMetricsForMatchmakingBooleanRuleResultInGameCenterMatchmakingRuleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/Relationships/GetMetricsForMatchmakingNumberRuleResultInGameCenterMatchmakingRuleV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/Relationships/GetMetricsForMatchmakingNumberRuleResultInGameCenterMatchmakingRuleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/Relationships/GetMetricsForMatchmakingRuleErrorInGameCenterMatchmakingRuleV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRule/Relationships/GetMetricsForMatchmakingRuleErrorInGameCenterMatchmakingRuleV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRuleSet/DeleteGameCenterMatchmakingRuleSetV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingRuleSet/DeleteGameCenterMatchmakingRuleSetV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingTeam/DeleteGameCenterMatchmakingTeamV1.swift
+++ b/Sources/BagbutikGameCenter/Endpoints/GameCenterMatchmakingTeam/DeleteGameCenterMatchmakingTeamV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikGameCenterModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikMarketplaces/Endpoints/AlternativeDistributionDomain/DeleteAlternativeDistributionDomainV1.swift
+++ b/Sources/BagbutikMarketplaces/Endpoints/AlternativeDistributionDomain/DeleteAlternativeDistributionDomainV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikMarketplacesModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikMarketplaces/Endpoints/AlternativeDistributionKey/DeleteAlternativeDistributionKeyV1.swift
+++ b/Sources/BagbutikMarketplaces/Endpoints/AlternativeDistributionKey/DeleteAlternativeDistributionKeyV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikMarketplacesModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikMarketplaces/Endpoints/AlternativeDistributionKey/ListAlternativeDistributionKeysV1.swift
+++ b/Sources/BagbutikMarketplaces/Endpoints/AlternativeDistributionKey/ListAlternativeDistributionKeysV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikMarketplacesModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikMarketplaces/Endpoints/MarketplaceSearchDetail/DeleteMarketplaceSearchDetailV1.swift
+++ b/Sources/BagbutikMarketplaces/Endpoints/MarketplaceSearchDetail/DeleteMarketplaceSearchDetailV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikMarketplacesModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikMarketplaces/Endpoints/MarketplaceWebhook/DeleteMarketplaceWebhookV1.swift
+++ b/Sources/BagbutikMarketplaces/Endpoints/MarketplaceWebhook/DeleteMarketplaceWebhookV1.swift
@@ -1,5 +1,6 @@
 import BagbutikCore
 import BagbutikMarketplacesModels
+import BagbutikModelsShared
 
 public extension Request {
     /**

--- a/Sources/BagbutikModelsShared/AppPerfPowerMetricsLinkagesResponse.swift
+++ b/Sources/BagbutikModelsShared/AppPerfPowerMetricsLinkagesResponse.swift
@@ -1,0 +1,54 @@
+import BagbutikCore
+import Foundation
+
+public struct AppPerfPowerMetricsLinkagesResponse: Codable, Sendable, PagedResponse {
+    public let data: [Data]
+    public let links: PagedDocumentLinks
+    public var meta: PagingInformation?
+
+    public init(data: [Data],
+                links: PagedDocumentLinks,
+                meta: PagingInformation? = nil)
+    {
+        self.data = data
+        self.links = links
+        self.meta = meta
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        data = try container.decode([Data].self, forKey: "data")
+        links = try container.decode(PagedDocumentLinks.self, forKey: "links")
+        meta = try container.decodeIfPresent(PagingInformation.self, forKey: "meta")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+        try container.encode(data, forKey: "data")
+        try container.encode(links, forKey: "links")
+        try container.encodeIfPresent(meta, forKey: "meta")
+    }
+
+    public struct Data: Codable, Sendable, Identifiable {
+        public let id: String
+        public var type: String { "perfPowerMetrics" }
+
+        public init(id: String) {
+            self.id = id
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            id = try container.decode(String.self, forKey: "id")
+            if try container.decode(String.self, forKey: "type") != type {
+                throw DecodingError.dataCorruptedError(forKey: "type", in: container, debugDescription: "Not matching \(type)")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: AnyCodingKey.self)
+            try container.encode(id, forKey: "id")
+            try container.encode(type, forKey: "type")
+        }
+    }
+}

--- a/Sources/BagbutikModelsShared/BuildPerfPowerMetricsLinkagesResponse.swift
+++ b/Sources/BagbutikModelsShared/BuildPerfPowerMetricsLinkagesResponse.swift
@@ -1,0 +1,54 @@
+import BagbutikCore
+import Foundation
+
+public struct BuildPerfPowerMetricsLinkagesResponse: Codable, Sendable, PagedResponse {
+    public let data: [Data]
+    public let links: PagedDocumentLinks
+    public var meta: PagingInformation?
+
+    public init(data: [Data],
+                links: PagedDocumentLinks,
+                meta: PagingInformation? = nil)
+    {
+        self.data = data
+        self.links = links
+        self.meta = meta
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        data = try container.decode([Data].self, forKey: "data")
+        links = try container.decode(PagedDocumentLinks.self, forKey: "links")
+        meta = try container.decodeIfPresent(PagingInformation.self, forKey: "meta")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+        try container.encode(data, forKey: "data")
+        try container.encode(links, forKey: "links")
+        try container.encodeIfPresent(meta, forKey: "meta")
+    }
+
+    public struct Data: Codable, Sendable, Identifiable {
+        public let id: String
+        public var type: String { "perfPowerMetrics" }
+
+        public init(id: String) {
+            self.id = id
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            id = try container.decode(String.self, forKey: "id")
+            if try container.decode(String.self, forKey: "type") != type {
+                throw DecodingError.dataCorruptedError(forKey: "type", in: container, debugDescription: "Not matching \(type)")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: AnyCodingKey.self)
+            try container.encode(id, forKey: "id")
+            try container.encode(type, forKey: "type")
+        }
+    }
+}

--- a/Sources/BagbutikModelsShared/DiagnosticSignatureLogsLinkagesResponse.swift
+++ b/Sources/BagbutikModelsShared/DiagnosticSignatureLogsLinkagesResponse.swift
@@ -1,0 +1,54 @@
+import BagbutikCore
+import Foundation
+
+public struct DiagnosticSignatureLogsLinkagesResponse: Codable, Sendable, PagedResponse {
+    public let data: [Data]
+    public let links: PagedDocumentLinks
+    public var meta: PagingInformation?
+
+    public init(data: [Data],
+                links: PagedDocumentLinks,
+                meta: PagingInformation? = nil)
+    {
+        self.data = data
+        self.links = links
+        self.meta = meta
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        data = try container.decode([Data].self, forKey: "data")
+        links = try container.decode(PagedDocumentLinks.self, forKey: "links")
+        meta = try container.decodeIfPresent(PagingInformation.self, forKey: "meta")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+        try container.encode(data, forKey: "data")
+        try container.encode(links, forKey: "links")
+        try container.encodeIfPresent(meta, forKey: "meta")
+    }
+
+    public struct Data: Codable, Sendable, Identifiable {
+        public let id: String
+        public var type: String { "diagnosticLogs" }
+
+        public init(id: String) {
+            self.id = id
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            id = try container.decode(String.self, forKey: "id")
+            if try container.decode(String.self, forKey: "type") != type {
+                throw DecodingError.dataCorruptedError(forKey: "type", in: container, debugDescription: "Not matching \(type)")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: AnyCodingKey.self)
+            try container.encode(id, forKey: "id")
+            try container.encode(type, forKey: "type")
+        }
+    }
+}

--- a/Sources/BagbutikModelsShared/InAppPurchaseOfferCodeOneTimeUseCodeValuesLinkageResponse.swift
+++ b/Sources/BagbutikModelsShared/InAppPurchaseOfferCodeOneTimeUseCodeValuesLinkageResponse.swift
@@ -1,0 +1,56 @@
+import BagbutikCore
+import Foundation
+
+/**
+ # InAppPurchaseOfferCodeOneTimeUseCodeValuesLinkageResponse
+ A response that contains a single in-app purchase offer code one-time use code values linkage resource.
+
+ Full documentation:
+ <https://developer.apple.com/documentation/appstoreconnectapi/inapppurchaseoffercodeonetimeusecodevalueslinkageresponse>
+ */
+public struct InAppPurchaseOfferCodeOneTimeUseCodeValuesLinkageResponse: Codable, Sendable {
+    public let data: Data
+    public let links: DocumentLinks
+
+    public init(data: Data,
+                links: DocumentLinks)
+    {
+        self.data = data
+        self.links = links
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        data = try container.decode(Data.self, forKey: "data")
+        links = try container.decode(DocumentLinks.self, forKey: "links")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+        try container.encode(data, forKey: "data")
+        try container.encode(links, forKey: "links")
+    }
+
+    public struct Data: Codable, Sendable, Identifiable {
+        public let id: String
+        public var type: String { "inAppPurchaseOfferCodeOneTimeUseCodeValues" }
+
+        public init(id: String) {
+            self.id = id
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            id = try container.decode(String.self, forKey: "id")
+            if try container.decode(String.self, forKey: "type") != type {
+                throw DecodingError.dataCorruptedError(forKey: "type", in: container, debugDescription: "Not matching \(type)")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: AnyCodingKey.self)
+            try container.encode(id, forKey: "id")
+            try container.encode(type, forKey: "type")
+        }
+    }
+}

--- a/Sources/BagbutikModelsShared/SubscriptionOfferCodeOneTimeUseCodeValuesLinkageResponse.swift
+++ b/Sources/BagbutikModelsShared/SubscriptionOfferCodeOneTimeUseCodeValuesLinkageResponse.swift
@@ -1,0 +1,49 @@
+import BagbutikCore
+import Foundation
+
+public struct SubscriptionOfferCodeOneTimeUseCodeValuesLinkageResponse: Codable, Sendable {
+    public let data: Data
+    public let links: DocumentLinks
+
+    public init(data: Data,
+                links: DocumentLinks)
+    {
+        self.data = data
+        self.links = links
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        data = try container.decode(Data.self, forKey: "data")
+        links = try container.decode(DocumentLinks.self, forKey: "links")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+        try container.encode(data, forKey: "data")
+        try container.encode(links, forKey: "links")
+    }
+
+    public struct Data: Codable, Sendable, Identifiable {
+        public let id: String
+        public var type: String { "subscriptionOfferCodeOneTimeUseCodeValues" }
+
+        public init(id: String) {
+            self.id = id
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: AnyCodingKey.self)
+            id = try container.decode(String.self, forKey: "id")
+            if try container.decode(String.self, forKey: "type") != type {
+                throw DecodingError.dataCorruptedError(forKey: "type", in: container, debugDescription: "Not matching \(type)")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: AnyCodingKey.self)
+            try container.encode(id, forKey: "id")
+            try container.encode(type, forKey: "type")
+        }
+    }
+}

--- a/Sources/BagbutikProvisioning/Endpoints/BundleId/DeleteBundleIdV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/BundleId/DeleteBundleIdV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/BundleId/ListBundleIdsV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/BundleId/ListBundleIdsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/BundleIdCapability/DeleteBundleIdCapabilityV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/BundleIdCapability/DeleteBundleIdCapabilityV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/Certificate/DeleteCertificateV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/Certificate/DeleteCertificateV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/Certificate/ListCertificatesV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/Certificate/ListCertificatesV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/Device/ListDevicesV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/Device/ListDevicesV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/MerchantId/DeleteMerchantIdV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/MerchantId/DeleteMerchantIdV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/MerchantId/ListMerchantIdsV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/MerchantId/ListMerchantIdsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/MerchantId/Relationships/ListCertificatesForMerchantIdV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/MerchantId/Relationships/ListCertificatesForMerchantIdV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/PassTypeId/DeletePassTypeIdV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/PassTypeId/DeletePassTypeIdV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/PassTypeId/ListPassTypeIdsV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/PassTypeId/ListPassTypeIdsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/PassTypeId/Relationships/ListCertificatesForPassTypeIdV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/PassTypeId/Relationships/ListCertificatesForPassTypeIdV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/Profile/DeleteProfileV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/Profile/DeleteProfileV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikProvisioning/Endpoints/Profile/ListProfilesV1.swift
+++ b/Sources/BagbutikProvisioning/Endpoints/Profile/ListProfilesV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikProvisioningModels
 
 public extension Request {

--- a/Sources/BagbutikReporting/Endpoints/AnalyticsReport/Relationships/ListInstancesForAnalyticsReportV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/AnalyticsReport/Relationships/ListInstancesForAnalyticsReportV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikReportingModels
 
 public extension Request {

--- a/Sources/BagbutikReporting/Endpoints/AnalyticsReportRequest/DeleteAnalyticsReportRequestV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/AnalyticsReportRequest/DeleteAnalyticsReportRequestV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikReportingModels
 
 public extension Request {

--- a/Sources/BagbutikReporting/Endpoints/AnalyticsReportRequest/Relationships/ListReportsForAnalyticsReportRequestV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/AnalyticsReportRequest/Relationships/ListReportsForAnalyticsReportRequestV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikReportingModels
 
 public extension Request {

--- a/Sources/BagbutikReporting/Endpoints/App/Relationships/ListPerfPowerMetricsForAppV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/App/Relationships/ListPerfPowerMetricsForAppV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikReportingModels
 
 public extension Request {

--- a/Sources/BagbutikReporting/Endpoints/FinanceReport/GetFinanceReportsV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/FinanceReport/GetFinanceReportsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikReportingModels
 
 public extension Request {

--- a/Sources/BagbutikReporting/Endpoints/SalesReport/GetSalesReportsV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/SalesReport/GetSalesReportsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikReportingModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/App/Relationships/DeleteBetaTestersForAppV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/App/Relationships/DeleteBetaTestersForAppV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/App/Relationships/GetMetricsForBetaTesterUsageInAppV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/App/Relationships/GetMetricsForBetaTesterUsageInAppV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/App/Relationships/ListBetaFeedbackCrashSubmissionsForAppV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/App/Relationships/ListBetaFeedbackCrashSubmissionsForAppV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/App/Relationships/ListBetaFeedbackScreenshotSubmissionsForAppV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/App/Relationships/ListBetaFeedbackScreenshotSubmissionsForAppV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaAppClipInvocation/DeleteBetaAppClipInvocationV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaAppClipInvocation/DeleteBetaAppClipInvocationV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaAppClipInvocationLocalization/DeleteBetaAppClipInvocationLocalizationV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaAppClipInvocationLocalization/DeleteBetaAppClipInvocationLocalizationV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaAppLocalization/DeleteBetaAppLocalizationV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaAppLocalization/DeleteBetaAppLocalizationV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaAppLocalization/ListBetaAppLocalizationsV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaAppLocalization/ListBetaAppLocalizationsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaAppReviewDetail/ListBetaAppReviewDetailsV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaAppReviewDetail/ListBetaAppReviewDetailsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaAppReviewSubmission/ListBetaAppReviewSubmissionsV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaAppReviewSubmission/ListBetaAppReviewSubmissionsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaBuildLocalization/DeleteBetaBuildLocalizationV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaBuildLocalization/DeleteBetaBuildLocalizationV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaBuildLocalization/ListBetaBuildLocalizationsV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaBuildLocalization/ListBetaBuildLocalizationsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaFeedbackCrashSubmission/DeleteBetaFeedbackCrashSubmissionV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaFeedbackCrashSubmission/DeleteBetaFeedbackCrashSubmissionV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaFeedbackScreenshotSubmission/DeleteBetaFeedbackScreenshotSubmissionV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaFeedbackScreenshotSubmission/DeleteBetaFeedbackScreenshotSubmissionV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaGroup/DeleteBetaGroupV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaGroup/DeleteBetaGroupV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaGroup/ListBetaGroupsV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaGroup/ListBetaGroupsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaGroup/Relationships/CreateBetaTestersForBetaGroupV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaGroup/Relationships/CreateBetaTestersForBetaGroupV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaGroup/Relationships/DeleteBetaTestersForBetaGroupV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaGroup/Relationships/DeleteBetaTestersForBetaGroupV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaGroup/Relationships/GetMetricsForBetaTesterUsageInBetaGroupV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaGroup/Relationships/GetMetricsForBetaTesterUsageInBetaGroupV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaLicenseAgreement/ListBetaLicenseAgreementsV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaLicenseAgreement/ListBetaLicenseAgreementsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaRecruitmentCriteria/DeleteBetaRecruitmentCriteriaV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaRecruitmentCriteria/DeleteBetaRecruitmentCriteriaV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaTester/DeleteBetaTesterV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaTester/DeleteBetaTesterV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaTester/ListBetaTestersV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaTester/ListBetaTestersV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaTester/Relationships/CreateBetaGroupsForBetaTesterV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaTester/Relationships/CreateBetaGroupsForBetaTesterV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaTester/Relationships/DeleteBetaGroupsForBetaTesterV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaTester/Relationships/DeleteBetaGroupsForBetaTesterV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BetaTester/Relationships/GetMetricsForBetaTesterUsageInBetaTesterV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BetaTester/Relationships/GetMetricsForBetaTesterUsageInBetaTesterV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikTestFlight/Endpoints/BuildBetaDetail/ListBuildBetaDetailsV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/BuildBetaDetail/ListBuildBetaDetailsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikTestFlightModels
 
 public extension Request {

--- a/Sources/BagbutikUsers/Endpoints/User/DeleteUserV1.swift
+++ b/Sources/BagbutikUsers/Endpoints/User/DeleteUserV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikUsersModels
 
 public extension Request {

--- a/Sources/BagbutikUsers/Endpoints/User/ListUsersV1.swift
+++ b/Sources/BagbutikUsers/Endpoints/User/ListUsersV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikUsersModels
 
 public extension Request {

--- a/Sources/BagbutikUsers/Endpoints/UserInvitation/DeleteUserInvitationV1.swift
+++ b/Sources/BagbutikUsers/Endpoints/UserInvitation/DeleteUserInvitationV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikUsersModels
 
 public extension Request {

--- a/Sources/BagbutikUsers/Endpoints/UserInvitation/ListUserInvitationsV1.swift
+++ b/Sources/BagbutikUsers/Endpoints/UserInvitation/ListUserInvitationsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikUsersModels
 
 public extension Request {

--- a/Sources/BagbutikWebhooks/Endpoints/Webhook/DeleteWebhookV1.swift
+++ b/Sources/BagbutikWebhooks/Endpoints/Webhook/DeleteWebhookV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikWebhooksModels
 
 public extension Request {

--- a/Sources/BagbutikWebhooks/Endpoints/Webhook/Relationships/ListDeliveriesForWebhookV1.swift
+++ b/Sources/BagbutikWebhooks/Endpoints/Webhook/Relationships/ListDeliveriesForWebhookV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikWebhooksModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/DeleteCiProductV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/DeleteCiProductV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/ListCiProductsV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/ListCiProductsV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/Relationships/ListAdditionalRepositoriesForCiProductV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/Relationships/ListAdditionalRepositoriesForCiProductV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/Relationships/ListBuildRunsForCiProductV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/Relationships/ListBuildRunsForCiProductV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/Relationships/ListPrimaryRepositoriesForCiProductV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/CiProduct/Relationships/ListPrimaryRepositoriesForCiProductV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/CiWorkflow/DeleteCiWorkflowV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/CiWorkflow/DeleteCiWorkflowV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/CiWorkflow/Relationships/ListBuildRunsForCiWorkflowV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/CiWorkflow/Relationships/ListBuildRunsForCiWorkflowV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/ScmProvider/Relationships/ListRepositoriesForScmProviderV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/ScmProvider/Relationships/ListRepositoriesForScmProviderV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Sources/BagbutikXcodeCloud/Endpoints/ScmRepository/ListScmRepositoriesV1.swift
+++ b/Sources/BagbutikXcodeCloud/Endpoints/ScmRepository/ListScmRepositoriesV1.swift
@@ -1,4 +1,5 @@
 import BagbutikCore
+import BagbutikModelsShared
 import BagbutikXcodeCloudModels
 
 public extension Request {

--- a/Tools/Sources/BagbutikGenerator/Generator.swift
+++ b/Tools/Sources/BagbutikGenerator/Generator.swift
@@ -36,7 +36,7 @@ typealias LoadSpec = (_ fileUrl: URL) throws -> Spec
 
 /// Generates endpoint and model source files from the decoded spec and normalized documentation.
 public class Generator {
-    private static let migratedPackages: Set<PackageName> = [.appStore, .gameCenter, .marketplaces, .provisioning, .reporting, .testFlight, .users, .webhooks, .xcodeCloud]
+    private static let domainPackages: Set<PackageName> = Set(PackageName.allCases).subtracting([.core])
     private static let sharedSchemas: Set<String> = [
         "App",
         "Build",
@@ -119,7 +119,6 @@ public class Generator {
         let modulePlan = RuntimeModulePlan(
             graph: schemaReferenceGraph,
             packageBySchema: packageBySchema,
-            migratedPackages: Self.migratedPackages,
             sharedSchemas: Self.sharedSchemas,
             additionalRootsByPackage: endpointRootsByPackage
         )
@@ -139,7 +138,7 @@ public class Generator {
             }
         }
         let generatedModelsDirectories = [RuntimeModulePlan.ModelModule.modelsShared.targetName]
-            + Self.migratedPackages
+            + Self.domainPackages
                 .map { RuntimeModulePlan.ModelModule.domainModels($0).targetName }
                 .sorted()
         for generatedModelsDirectory in generatedModelsDirectories {
@@ -158,7 +157,7 @@ public class Generator {
                         let fileName = "\(name).swift"
                         let packageName = try await Self.resolvePackageName(for: operation, docsLoader: docsLoader)
                         var renderedOperation = try await operationRenderer.render(operation: operation, in: path) + "\n"
-                        if Self.migratedPackages.contains(packageName) {
+                        if Self.domainPackages.contains(packageName) {
                             let domainModelModule = RuntimeModulePlan.ModelModule.domainModels(packageName)
                             renderedOperation = renderedOperation
                                 .replacingOccurrences(
@@ -194,7 +193,6 @@ public class Generator {
                 taskGroup.addTask { [docsLoader, schemas, packageBySchema, schemaReferenceGraph, modulePlan] in
                     let packageName = packageBySchema[schema.name]!
                     let modelModule = modulePlan[schema.name]
-                    guard modelModule != .unassigned else { return nil }
                     let referencedModelModules = Set(schemaReferenceGraph.references[schema.name, default: []]
                         .map { modulePlan[$0] })
                     let model = try await Generator.generateModel(
@@ -211,8 +209,6 @@ public class Generator {
                         outputDirURL.appendingPathComponent(modelModule.targetName)
                     case .core:
                         outputDirURL.appendingPathComponent("BagbutikCore").appendingPathComponent("Models")
-                    case .unassigned:
-                        fatalError("Unassigned models are not rendered")
                     }
                     return .init(dirURL: modelsDirURL, name: model.name, fileName: fileName, contents: model.contents)
                 }
@@ -323,7 +319,7 @@ public class Generator {
         modulePlan: RuntimeModulePlan
     ) -> String {
         var directlyReferencedModules = Set(endpointSchemaNames(for: operation).map { modulePlan[$0] })
-            .subtracting([.core, .unassigned, domainModelModule])
+            .subtracting([.core, domainModelModule])
         directlyReferencedModules.insert(domainModelModule)
         return directlyReferencedModules
             .map(\.targetName)
@@ -369,20 +365,18 @@ public class Generator {
         case .modelsShared:
             let dependencies = (referencedModelModules ?? [])
                 .union([.core])
-                .subtracting([.modelsShared, .unassigned])
+                .subtracting([.modelsShared])
             imports.append(contentsOf: dependencies
                 .sorted { $0.targetName < $1.targetName }
                 .map { "import \($0.targetName)" })
         case let .domainModels(package):
             let dependencies = (referencedModelModules ?? [])
                 .union([.core])
-                .subtracting([.domainModels(package), .unassigned])
+                .subtracting([.domainModels(package)])
             imports.append(contentsOf: dependencies
                 .sorted { $0.targetName < $1.targetName }
                 .map { "import \($0.targetName)" })
         case .core:
-            break
-        case .unassigned:
             break
         }
         let contents = """

--- a/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
+++ b/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
@@ -2,39 +2,30 @@ import BagbutikDocsCollector
 import BagbutikSpecDecoder
 import Foundation
 
-/// The model module assignment used while the version 24 graph is migrated one product at a time.
+/// Assigns every generated schema to its final version 24 model module.
 public struct RuntimeModulePlan: Sendable {
     public enum ModelModule: Hashable, Sendable {
         case core
         case modelsShared
         case domainModels(PackageName)
-        case unassigned
 
         public var targetName: String {
             switch self {
             case .core: "BagbutikCore"
             case .modelsShared: "BagbutikModelsShared"
             case .domainModels(let package): "Bagbutik\(package.docsSectionName)Models"
-            case .unassigned: ""
             }
         }
 
-        public var isGeneratedModelModule: Bool {
-            switch self {
-            case .modelsShared, .domainModels: true
-            case .core, .unassigned: false
-            }
-        }
     }
 
     public let moduleBySchema: [String: ModelModule]
     public let dependenciesByModule: [ModelModule: Set<ModelModule>]
 
-    /// Creates version 24 vertical slices from schema ownership and actual references.
+    /// Creates version 24 model assignments from schema ownership and endpoint references.
     public init(
         graph: SchemaReferenceGraph,
         packageBySchema: [String: PackageName],
-        migratedPackages: Set<PackageName>,
         sharedSchemas: Set<String> = [],
         additionalRootsByPackage: [PackageName: Set<String>] = [:]
     ) {
@@ -43,40 +34,32 @@ public struct RuntimeModulePlan: Sendable {
                   !Self.isLinkageSchema(entry.key) else { return nil }
             return entry.key
         })
-        let schemasByPackage = migratedPackages.reduce(into: [PackageName: Set<String>]()) { result, package in
-            result[package] = Set(packageBySchema.compactMap { $0.value == package ? $0.key : nil })
-                .union(additionalRootsByPackage[package, default: []])
-        }
-        let closureByPackage = schemasByPackage.mapValues { graph.closure(startingAt: $0) }
-        let migratedClosure = closureByPackage.values.reduce(into: Set<String>()) { $0.formUnion($1) }
+        let closureByPackage = additionalRootsByPackage.mapValues { graph.closure(startingAt: $0) }
 
         var assignments = graph.references.keys.reduce(into: [String: ModelModule]()) { result, schema in
             if coreSchemas.contains(schema) {
                 result[schema] = .core
-            } else if migratedClosure.contains(schema) {
-                let usingPackages = migratedPackages.filter { closureByPackage[$0, default: []].contains(schema) }
-                if sharedSchemas.contains(schema) {
-                    result[schema] = .modelsShared
-                } else if let owner = packageBySchema[schema], migratedPackages.contains(owner) {
-                    result[schema] = .domainModels(owner)
-                } else if Self.isLinkageSchema(schema), usingPackages.count == 1, let package = usingPackages.first {
-                    result[schema] = .domainModels(package)
-                } else {
-                    result[schema] = .modelsShared
+            } else if sharedSchemas.contains(schema) {
+                result[schema] = .modelsShared
+            } else if let owner = packageBySchema[schema], owner != .core {
+                result[schema] = .domainModels(owner)
+            } else if Self.isLinkageSchema(schema) {
+                let usingPackages = closureByPackage.compactMap { package, closure in
+                    closure.contains(schema) ? package : nil
                 }
+                result[schema] = usingPackages.count == 1
+                    ? .domainModels(usingPackages[0])
+                    : .modelsShared
             } else {
-                result[schema] = .unassigned
+                result[schema] = .core
             }
         }
 
         for component in graph.stronglyConnectedComponents() {
             let modules = Set(component.schemas.compactMap { assignments[$0] })
-                .subtracting([.unassigned])
             guard modules.count > 1 else { continue }
             let collapsedModule: ModelModule = modules.contains(.core) ? .core : .modelsShared
-            for schema in component.schemas where assignments[schema] != .unassigned {
-                assignments[schema] = collapsedModule
-            }
+            for schema in component.schemas { assignments[schema] = collapsedModule }
         }
 
         var pendingSharedSchemas = assignments.compactMap { schema, module in
@@ -95,15 +78,14 @@ public struct RuntimeModulePlan: Sendable {
         var dependencies: [ModelModule: Set<ModelModule>] = [
             .modelsShared: [.core],
         ]
-        for package in migratedPackages {
+        for package in PackageName.allCases where package != .core {
             dependencies[.domainModels(package), default: []].formUnion([.core, .modelsShared])
         }
         for (schema, references) in graph.references {
-            guard let sourceModule = assignments[schema], sourceModule != .unassigned else { continue }
+            guard let sourceModule = assignments[schema] else { continue }
             for reference in references {
                 guard let dependencyModule = assignments[reference],
-                      dependencyModule != sourceModule,
-                      dependencyModule != .unassigned else { continue }
+                      dependencyModule != sourceModule else { continue }
                 dependencies[sourceModule, default: []].insert(dependencyModule)
             }
         }
@@ -111,7 +93,7 @@ public struct RuntimeModulePlan: Sendable {
     }
 
     public subscript(schemaName: String) -> ModelModule {
-        moduleBySchema[schemaName, default: .unassigned]
+        moduleBySchema[schemaName, default: .modelsShared]
     }
 
     public func dependencies(for module: ModelModule) -> Set<ModelModule> {

--- a/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
+++ b/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
@@ -2,7 +2,7 @@ import BagbutikDocsCollector
 import BagbutikSpecDecoder
 import Foundation
 
-/// Assigns every generated schema to its final version 24 model module.
+/// Assigns every generated schema to its final model module.
 public struct RuntimeModulePlan: Sendable {
     public enum ModelModule: Hashable, Sendable {
         case core

--- a/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
+++ b/Tools/Sources/BagbutikGenerator/RuntimeModulePlan.swift
@@ -22,7 +22,7 @@ public struct RuntimeModulePlan: Sendable {
     public let moduleBySchema: [String: ModelModule]
     public let dependenciesByModule: [ModelModule: Set<ModelModule>]
 
-    /// Creates version 24 model assignments from schema ownership and endpoint references.
+    /// Creates model assignments from schema ownership and endpoint references.
     public init(
         graph: SchemaReferenceGraph,
         packageBySchema: [String: PackageName],

--- a/Tools/Tests/BagbutikGeneratorTests/RuntimeModulePlanTests.swift
+++ b/Tools/Tests/BagbutikGeneratorTests/RuntimeModulePlanTests.swift
@@ -32,15 +32,14 @@ final class RuntimeModulePlanTests: XCTestCase {
         let plan = RuntimeModulePlan(
             graph: .init(schemas: schemas),
             packageBySchema: packages,
-            migratedPackages: [.users]
         )
 
         XCTAssertEqual(plan["CoreLinks"], .core)
-        XCTAssertEqual(plan["App"], .modelsShared)
-        XCTAssertEqual(plan["SubscriptionStatusUrlVersion"], .modelsShared)
+        XCTAssertEqual(plan["App"], .domainModels(.appStore))
+        XCTAssertEqual(plan["SubscriptionStatusUrlVersion"], .domainModels(.appStore))
         XCTAssertEqual(plan["User"], .domainModels(.users))
         XCTAssertEqual(plan["UsersResponse"], .domainModels(.users))
-        XCTAssertEqual(plan["Build"], .unassigned)
+        XCTAssertEqual(plan["Build"], .domainModels(.appStore))
     }
 
     func testCrossDomainCycleIsKeptInOneSharedModule() {
@@ -57,7 +56,6 @@ final class RuntimeModulePlanTests: XCTestCase {
         let plan = RuntimeModulePlan(
             graph: .init(schemas: schemas),
             packageBySchema: packages,
-            migratedPackages: [.users]
         )
 
         XCTAssertEqual(plan["User"], .modelsShared)
@@ -81,7 +79,6 @@ final class RuntimeModulePlanTests: XCTestCase {
         let plan = RuntimeModulePlan(
             graph: .init(schemas: schemas),
             packageBySchema: packages,
-            migratedPackages: [.users, .webhooks],
             additionalRootsByPackage: [.webhooks: ["WebhookDeliveriesLinkagesResponse"]]
         )
 
@@ -114,7 +111,7 @@ final class RuntimeModulePlanTests: XCTestCase {
         let plan = RuntimeModulePlan(
             graph: .init(schemas: schemas),
             packageBySchema: packages,
-            migratedPackages: [.users, .xcodeCloud]
+            sharedSchemas: ["SharedRule"]
         )
 
         XCTAssertEqual(plan["SharedRule"], .modelsShared)
@@ -141,7 +138,6 @@ final class RuntimeModulePlanTests: XCTestCase {
         let plan = RuntimeModulePlan(
             graph: .init(schemas: schemas),
             packageBySchema: packages,
-            migratedPackages: [.provisioning, .testFlight],
             sharedSchemas: ["DeviceFamily"]
         )
 
@@ -172,13 +168,12 @@ final class RuntimeModulePlanTests: XCTestCase {
         let plan = RuntimeModulePlan(
             graph: .init(schemas: schemas),
             packageBySchema: packages,
-            migratedPackages: [.appStore]
         )
 
         XCTAssertEqual(plan["CustomerReview"], .domainModels(.appStore))
         XCTAssertEqual(plan["Territory"], .domainModels(.appStore))
         XCTAssertEqual(plan["UnrelatedAppClip"], .domainModels(.appStore))
-        XCTAssertEqual(plan["UnrelatedGameCenterActivity"], .unassigned)
+        XCTAssertEqual(plan["UnrelatedGameCenterActivity"], .domainModels(.gameCenter))
         XCTAssertEqual(
             plan.dependencies(for: .domainModels(.appStore)),
             [.core, .modelsShared]
@@ -206,7 +201,6 @@ final class RuntimeModulePlanTests: XCTestCase {
         let plan = RuntimeModulePlan(
             graph: .init(schemas: schemas),
             packageBySchema: packages,
-            migratedPackages: [.appStore, .gameCenter],
             sharedSchemas: ["GameCenterVersion"]
         )
 


### PR DESCRIPTION
## Summary

- remove the temporary `unassigned` model module from the generator
- assign every schema to its final core, shared, or domain model module
- regenerate endpoint imports and previously omitted shared linkage models

This is a stacked follow up to #328 and should be reviewed after the source folder rename.

## Validation

- `swift test --package-path Tools --disable-sandbox`
- `swift test --disable-sandbox`
- generator completed without errors
- `git diff --check`
- `bash -n scripts/build-xcframework.sh`
- `swift package dump-package --disable-sandbox`