### PR TITLE
Verify generated sources in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       run: swift test -v --enable-code-coverage --xunit-output .build/test-results.xml
     - name: Test Maintainer Tools
       run: swift test -v --package-path Tools --enable-code-coverage
+    - name: Verify generated sources
+      run: |
+        swift run --package-path Tools bagbutik-cli generate --spec-path 'openapi.oas (2).json' --output-path Sources --documentation-path Documentation
+        git diff --exit-code -- Sources
     - name: Generate runtime LCOV coverage report
       id: runtime_coverage
       run: |


### PR DESCRIPTION
## Summary

- regenerate sources from the checked in OpenAPI specification and documentation during macOS CI
- fail when regeneration changes `Sources/`
- prevent generated endpoints or reachable schemas from disappearing from a source package release

## Audit

- compared v23.0.0 endpoint file names with current v24 sources: no current endpoint omissions
- confirmed all 30 reported Build endpoints are present in their v24 domain targets
- generated a clean output: 1,263 endpoints and 1,392 models
- confirmed every fresh generated Swift file exists in `Sources/`
- `AppStoreVersionAgeRatingDeclarationLinkageResponse` is absent from the current OpenAPI specification and has no endpoint or schema references

## Validation

- in place generator run with no `Sources/` diff
- `swift test --package-path Tools --disable-sandbox`
- `git diff --check`