### PR TITLE
Restore generated Build endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 xcuserdata
 .DS_Store
 .build
-build
+/build
 output
 coverage.lcov
 docs

--- a/Sources/BagbutikAppStore/Endpoints/Build/GetBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/GetBuildV1.swift
@@ -1,0 +1,533 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Read build information
+     Get information about a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Parameter includes: Relationship data to include in the response
+     - Parameter limits: Number of resources to return
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getBuildV1(id: String,
+                           fields: [GetBuildV1.Field]? = nil,
+                           includes: [GetBuildV1.Include]? = nil,
+                           limits: [GetBuildV1.Limit]? = nil) -> Request<BuildResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                includes: includes,
+                limits: limits))
+    }
+}
+
+public enum GetBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type appEncryptionDeclarations
+        case appEncryptionDeclarations([AppEncryptionDeclarations])
+        /// The fields to include for returned resources of type appStoreVersions
+        case appStoreVersions([AppStoreVersions])
+        /// The fields to include for returned resources of type apps
+        case apps([Apps])
+        /// The fields to include for returned resources of type betaAppReviewSubmissions
+        case betaAppReviewSubmissions([BetaAppReviewSubmissions])
+        /// The fields to include for returned resources of type betaBuildLocalizations
+        case betaBuildLocalizations([BetaBuildLocalizations])
+        /// The fields to include for returned resources of type betaGroups
+        case betaGroups([BetaGroups])
+        /// The fields to include for returned resources of type betaTesters
+        case betaTesters([BetaTesters])
+        /// The fields to include for returned resources of type buildBetaDetails
+        case buildBetaDetails([BuildBetaDetails])
+        /// The fields to include for returned resources of type buildBundles
+        case buildBundles([BuildBundles])
+        /// The fields to include for returned resources of type buildIcons
+        case buildIcons([BuildIcons])
+        /// The fields to include for returned resources of type buildUploads
+        case buildUploads([BuildUploads])
+        /// The fields to include for returned resources of type builds
+        case builds([Builds])
+        /// The fields to include for returned resources of type preReleaseVersions
+        case preReleaseVersions([PreReleaseVersions])
+
+        public enum AppEncryptionDeclarations: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appDescription
+            case appEncryptionDeclarationDocument
+            case appEncryptionDeclarationState
+            case availableOnFrenchStore
+            case builds
+            case codeValue
+            case containsProprietaryCryptography
+            case containsThirdPartyCryptography
+            case createdDate
+            case documentName
+            case documentType
+            case documentUrl
+            case exempt
+            case platform
+            case uploadedDate
+            case usesEncryption
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppEncryptionDeclarations(rawValue: string) {
+                    self = value
+                } else if let value = AppEncryptionDeclarations(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppEncryptionDeclarations value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreVersions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case alternativeDistributionPackage
+            case app
+            case appClipDefaultExperience
+            case appStoreReviewDetail
+            case appStoreState
+            case appStoreVersionExperiments
+            case appStoreVersionExperimentsV2
+            case appStoreVersionLocalizations
+            case appStoreVersionPhasedRelease
+            case appStoreVersionSubmission
+            case appVersionState
+            case build
+            case copyright
+            case createdDate
+            case customerReviews
+            case downloadable
+            case earliestReleaseDate
+            case gameCenterAppVersion
+            case platform
+            case releaseType
+            case reviewType
+            case routingAppCoverage
+            case usesIdfa
+            case versionString
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreVersions(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreVersions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreVersions value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Apps: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case accessibilityDeclarations
+            case accessibilityUrl
+            case alternativeDistributionKey
+            case analyticsReportRequests
+            case androidToIosAppMappingDetails
+            case appAvailabilityV2
+            case appClips
+            case appCustomProductPages
+            case appEncryptionDeclarations
+            case appEvents
+            case appInfos
+            case appPricePoints
+            case appPriceSchedule
+            case appStoreIcon
+            case appStoreVersionExperimentsV2
+            case appStoreVersions
+            case appTags
+            case backgroundAssets
+            case betaAppLocalizations
+            case betaAppReviewDetail
+            case betaFeedbackCrashSubmissions
+            case betaFeedbackScreenshotSubmissions
+            case betaGroups
+            case betaLicenseAgreement
+            case betaTesters
+            case buildUploads
+            case builds
+            case bundleId
+            case ciProduct
+            case contentRightsDeclaration
+            case customerReviewSummarizations
+            case customerReviews
+            case endUserLicenseAgreement
+            case gameCenterDetail
+            case gameCenterEnabledVersions
+            case inAppPurchases
+            case inAppPurchasesV2
+            case isOrEverWasMadeForKids
+            case marketplaceSearchDetail
+            case name
+            case perfPowerMetrics
+            case preReleaseVersions
+            case primaryLocale
+            case promotedPurchases
+            case reviewSubmissions
+            case searchKeywords
+            case sku
+            case streamlinedPurchasingEnabled
+            case subscriptionGracePeriod
+            case subscriptionGroups
+            case subscriptionStatusUrl
+            case subscriptionStatusUrlForSandbox
+            case subscriptionStatusUrlVersion
+            case subscriptionStatusUrlVersionForSandbox
+            case webhooks
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Apps(rawValue: string) {
+                    self = value
+                } else if let value = Apps(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Apps value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaAppReviewSubmissions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case betaReviewState
+            case build
+            case submittedDate
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaAppReviewSubmissions(rawValue: string) {
+                    self = value
+                } else if let value = BetaAppReviewSubmissions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaAppReviewSubmissions value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaBuildLocalizations: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case build
+            case locale
+            case whatsNew
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaBuildLocalizations(rawValue: string) {
+                    self = value
+                } else if let value = BetaBuildLocalizations(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaBuildLocalizations value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaGroups: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case betaRecruitmentCriteria
+            case betaRecruitmentCriterionCompatibleBuildCheck
+            case betaTesters
+            case builds
+            case createdDate
+            case feedbackEnabled
+            case hasAccessToAllBuilds
+            case iosBuildsAvailableForAppleSiliconMac
+            case iosBuildsAvailableForAppleVision
+            case isInternalGroup
+            case name
+            case publicLink
+            case publicLinkEnabled
+            case publicLinkId
+            case publicLinkLimit
+            case publicLinkLimitEnabled
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaGroups(rawValue: string) {
+                    self = value
+                } else if let value = BetaGroups(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaGroups value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaTesters: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appDevices
+            case apps
+            case betaGroups
+            case builds
+            case email
+            case firstName
+            case inviteType
+            case lastName
+            case state
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaTesters(rawValue: string) {
+                    self = value
+                } else if let value = BetaTesters(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaTesters value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildBetaDetails: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case autoNotifyEnabled
+            case build
+            case externalBuildState
+            case internalBuildState
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildBetaDetails(rawValue: string) {
+                    self = value
+                } else if let value = BuildBetaDetails(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildBetaDetails value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildBundles: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appClipDomainCacheStatus
+            case appClipDomainDebugStatus
+            case baDownloadAllowance
+            case baMaxInstallSize
+            case betaAppClipInvocations
+            case buildBundleFileSizes
+            case bundleId
+            case bundleType
+            case dSYMUrl
+            case deviceProtocols
+            case entitlements
+            case fileName
+            case hasOnDemandResources
+            case hasPrerenderedIcon
+            case hasSirikit
+            case includesSymbols
+            case isIosBuildMacAppStoreCompatible
+            case locales
+            case minimumOsVersion
+            case platformBuild
+            case requiredCapabilities
+            case sdkBuild
+            case supportedArchitectures
+            case usesLocationServices
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildBundles(rawValue: string) {
+                    self = value
+                } else if let value = BuildBundles(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildBundles value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildIcons: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case iconAsset
+            case iconType
+            case masked
+            case name
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildIcons(rawValue: string) {
+                    self = value
+                } else if let value = BuildIcons(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildIcons value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildUploads: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case assetDescriptionFile
+            case assetFile
+            case assetSpiFile
+            case build
+            case buildUploadFiles
+            case cfBundleShortVersionString
+            case cfBundleVersion
+            case createdDate
+            case platform
+            case state
+            case uploadedDate
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildUploads(rawValue: string) {
+                    self = value
+                } else if let value = BuildUploads(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildUploads value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Builds: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appEncryptionDeclaration
+            case appStoreVersion
+            case betaAppReviewSubmission
+            case betaBuildLocalizations
+            case betaGroups
+            case buildAudienceType
+            case buildBetaDetail
+            case buildBundles
+            case buildUpload
+            case computedMinMacOsVersion
+            case computedMinVisionOsVersion
+            case diagnosticSignatures
+            case expirationDate
+            case expired
+            case iconAssetToken
+            case icons
+            case individualTesters
+            case lsMinimumSystemVersion
+            case minOsVersion
+            case perfPowerMetrics
+            case preReleaseVersion
+            case processingState
+            case uploadedDate
+            case usesNonExemptEncryption
+            case version
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Builds(rawValue: string) {
+                    self = value
+                } else if let value = Builds(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Builds value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum PreReleaseVersions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case builds
+            case platform
+            case version
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = PreReleaseVersions(rawValue: string) {
+                    self = value
+                } else if let value = PreReleaseVersions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid PreReleaseVersions value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     Relationship data to include in the response.
+     */
+    public enum Include: String, IncludeParameter, CaseIterable {
+        case app
+        case appEncryptionDeclaration
+        case appStoreVersion
+        case betaAppReviewSubmission
+        case betaBuildLocalizations
+        case betaGroups
+        case buildBetaDetail
+        case buildBundles
+        case buildUpload
+        case icons
+        case individualTesters
+        case preReleaseVersion
+    }
+
+    /**
+     Number of included related resources to return.
+     */
+    public enum Limit: LimitParameter {
+        /// Maximum number of related betaBuildLocalizations returned (when they are included) - maximum 50
+        case betaBuildLocalizations(Int)
+        /// Maximum number of related betaGroups returned (when they are included) - maximum 50
+        case betaGroups(Int)
+        /// Maximum number of related buildBundles returned (when they are included) - maximum 50
+        case buildBundles(Int)
+        /// Maximum number of related icons returned (when they are included) - maximum 50
+        case icons(Int)
+        /// Maximum number of related individualTesters returned (when they are included) - maximum 50
+        case individualTesters(Int)
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/ListBuildsV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/ListBuildsV1.swift
@@ -1,0 +1,596 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+import BagbutikModelsShared
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # List builds
+     Find and list builds for all apps in App Store Connect.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds>
+
+     - Parameter fields: Fields to return for included related types
+     - Parameter filters: Attributes, relationships, and IDs by which to filter
+     - Parameter exists: Attributes, relationships, and IDs to check for existence
+     - Parameter includes: Relationship data to include in the response
+     - Parameter sorts: Attributes by which to sort
+     - Parameter limits: Number of resources to return
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listBuildsV1(fields: [ListBuildsV1.Field]? = nil,
+                             filters: [ListBuildsV1.Filter]? = nil,
+                             exists: [ListBuildsV1.Exist]? = nil,
+                             includes: [ListBuildsV1.Include]? = nil,
+                             sorts: [ListBuildsV1.Sort]? = nil,
+                             limits: [ListBuildsV1.Limit]? = nil) -> Request<BuildsResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                filters: filters,
+                exists: exists,
+                includes: includes,
+                sorts: sorts,
+                limits: limits))
+    }
+}
+
+public enum ListBuildsV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type appEncryptionDeclarations
+        case appEncryptionDeclarations([AppEncryptionDeclarations])
+        /// The fields to include for returned resources of type appStoreVersions
+        case appStoreVersions([AppStoreVersions])
+        /// The fields to include for returned resources of type apps
+        case apps([Apps])
+        /// The fields to include for returned resources of type betaAppReviewSubmissions
+        case betaAppReviewSubmissions([BetaAppReviewSubmissions])
+        /// The fields to include for returned resources of type betaBuildLocalizations
+        case betaBuildLocalizations([BetaBuildLocalizations])
+        /// The fields to include for returned resources of type betaGroups
+        case betaGroups([BetaGroups])
+        /// The fields to include for returned resources of type betaTesters
+        case betaTesters([BetaTesters])
+        /// The fields to include for returned resources of type buildBetaDetails
+        case buildBetaDetails([BuildBetaDetails])
+        /// The fields to include for returned resources of type buildBundles
+        case buildBundles([BuildBundles])
+        /// The fields to include for returned resources of type buildIcons
+        case buildIcons([BuildIcons])
+        /// The fields to include for returned resources of type buildUploads
+        case buildUploads([BuildUploads])
+        /// The fields to include for returned resources of type builds
+        case builds([Builds])
+        /// The fields to include for returned resources of type preReleaseVersions
+        case preReleaseVersions([PreReleaseVersions])
+
+        public enum AppEncryptionDeclarations: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appDescription
+            case appEncryptionDeclarationDocument
+            case appEncryptionDeclarationState
+            case availableOnFrenchStore
+            case builds
+            case codeValue
+            case containsProprietaryCryptography
+            case containsThirdPartyCryptography
+            case createdDate
+            case documentName
+            case documentType
+            case documentUrl
+            case exempt
+            case platform
+            case uploadedDate
+            case usesEncryption
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppEncryptionDeclarations(rawValue: string) {
+                    self = value
+                } else if let value = AppEncryptionDeclarations(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppEncryptionDeclarations value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreVersions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case alternativeDistributionPackage
+            case app
+            case appClipDefaultExperience
+            case appStoreReviewDetail
+            case appStoreState
+            case appStoreVersionExperiments
+            case appStoreVersionExperimentsV2
+            case appStoreVersionLocalizations
+            case appStoreVersionPhasedRelease
+            case appStoreVersionSubmission
+            case appVersionState
+            case build
+            case copyright
+            case createdDate
+            case customerReviews
+            case downloadable
+            case earliestReleaseDate
+            case gameCenterAppVersion
+            case platform
+            case releaseType
+            case reviewType
+            case routingAppCoverage
+            case usesIdfa
+            case versionString
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreVersions(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreVersions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreVersions value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Apps: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case accessibilityDeclarations
+            case accessibilityUrl
+            case alternativeDistributionKey
+            case analyticsReportRequests
+            case androidToIosAppMappingDetails
+            case appAvailabilityV2
+            case appClips
+            case appCustomProductPages
+            case appEncryptionDeclarations
+            case appEvents
+            case appInfos
+            case appPricePoints
+            case appPriceSchedule
+            case appStoreIcon
+            case appStoreVersionExperimentsV2
+            case appStoreVersions
+            case appTags
+            case backgroundAssets
+            case betaAppLocalizations
+            case betaAppReviewDetail
+            case betaFeedbackCrashSubmissions
+            case betaFeedbackScreenshotSubmissions
+            case betaGroups
+            case betaLicenseAgreement
+            case betaTesters
+            case buildUploads
+            case builds
+            case bundleId
+            case ciProduct
+            case contentRightsDeclaration
+            case customerReviewSummarizations
+            case customerReviews
+            case endUserLicenseAgreement
+            case gameCenterDetail
+            case gameCenterEnabledVersions
+            case inAppPurchases
+            case inAppPurchasesV2
+            case isOrEverWasMadeForKids
+            case marketplaceSearchDetail
+            case name
+            case perfPowerMetrics
+            case preReleaseVersions
+            case primaryLocale
+            case promotedPurchases
+            case reviewSubmissions
+            case searchKeywords
+            case sku
+            case streamlinedPurchasingEnabled
+            case subscriptionGracePeriod
+            case subscriptionGroups
+            case subscriptionStatusUrl
+            case subscriptionStatusUrlForSandbox
+            case subscriptionStatusUrlVersion
+            case subscriptionStatusUrlVersionForSandbox
+            case webhooks
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Apps(rawValue: string) {
+                    self = value
+                } else if let value = Apps(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Apps value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaAppReviewSubmissions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case betaReviewState
+            case build
+            case submittedDate
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaAppReviewSubmissions(rawValue: string) {
+                    self = value
+                } else if let value = BetaAppReviewSubmissions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaAppReviewSubmissions value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaBuildLocalizations: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case build
+            case locale
+            case whatsNew
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaBuildLocalizations(rawValue: string) {
+                    self = value
+                } else if let value = BetaBuildLocalizations(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaBuildLocalizations value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaGroups: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case betaRecruitmentCriteria
+            case betaRecruitmentCriterionCompatibleBuildCheck
+            case betaTesters
+            case builds
+            case createdDate
+            case feedbackEnabled
+            case hasAccessToAllBuilds
+            case iosBuildsAvailableForAppleSiliconMac
+            case iosBuildsAvailableForAppleVision
+            case isInternalGroup
+            case name
+            case publicLink
+            case publicLinkEnabled
+            case publicLinkId
+            case publicLinkLimit
+            case publicLinkLimitEnabled
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaGroups(rawValue: string) {
+                    self = value
+                } else if let value = BetaGroups(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaGroups value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BetaTesters: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appDevices
+            case apps
+            case betaGroups
+            case builds
+            case email
+            case firstName
+            case inviteType
+            case lastName
+            case state
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaTesters(rawValue: string) {
+                    self = value
+                } else if let value = BetaTesters(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaTesters value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildBetaDetails: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case autoNotifyEnabled
+            case build
+            case externalBuildState
+            case internalBuildState
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildBetaDetails(rawValue: string) {
+                    self = value
+                } else if let value = BuildBetaDetails(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildBetaDetails value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildBundles: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appClipDomainCacheStatus
+            case appClipDomainDebugStatus
+            case baDownloadAllowance
+            case baMaxInstallSize
+            case betaAppClipInvocations
+            case buildBundleFileSizes
+            case bundleId
+            case bundleType
+            case dSYMUrl
+            case deviceProtocols
+            case entitlements
+            case fileName
+            case hasOnDemandResources
+            case hasPrerenderedIcon
+            case hasSirikit
+            case includesSymbols
+            case isIosBuildMacAppStoreCompatible
+            case locales
+            case minimumOsVersion
+            case platformBuild
+            case requiredCapabilities
+            case sdkBuild
+            case supportedArchitectures
+            case usesLocationServices
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildBundles(rawValue: string) {
+                    self = value
+                } else if let value = BuildBundles(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildBundles value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildIcons: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case iconAsset
+            case iconType
+            case masked
+            case name
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildIcons(rawValue: string) {
+                    self = value
+                } else if let value = BuildIcons(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildIcons value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum BuildUploads: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case assetDescriptionFile
+            case assetFile
+            case assetSpiFile
+            case build
+            case buildUploadFiles
+            case cfBundleShortVersionString
+            case cfBundleVersion
+            case createdDate
+            case platform
+            case state
+            case uploadedDate
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildUploads(rawValue: string) {
+                    self = value
+                } else if let value = BuildUploads(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildUploads value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Builds: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appEncryptionDeclaration
+            case appStoreVersion
+            case betaAppReviewSubmission
+            case betaBuildLocalizations
+            case betaGroups
+            case buildAudienceType
+            case buildBetaDetail
+            case buildBundles
+            case buildUpload
+            case computedMinMacOsVersion
+            case computedMinVisionOsVersion
+            case diagnosticSignatures
+            case expirationDate
+            case expired
+            case iconAssetToken
+            case icons
+            case individualTesters
+            case lsMinimumSystemVersion
+            case minOsVersion
+            case perfPowerMetrics
+            case preReleaseVersion
+            case processingState
+            case uploadedDate
+            case usesNonExemptEncryption
+            case version
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Builds(rawValue: string) {
+                    self = value
+                } else if let value = Builds(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Builds value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum PreReleaseVersions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case builds
+            case platform
+            case version
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = PreReleaseVersions(rawValue: string) {
+                    self = value
+                } else if let value = PreReleaseVersions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid PreReleaseVersions value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     Attributes, relationships, and IDs by which to filter.
+     */
+    public enum Filter: FilterParameter {
+        /// Filter by id(s) of related 'app'
+        case app([String])
+        /// Filter by id(s) of related 'appStoreVersion'
+        case appStoreVersion([String])
+        /// Filter by attribute 'betaAppReviewSubmission.betaReviewState'
+        case betaAppReviewSubmission_betaReviewState([BetaReviewState])
+        /// Filter by id(s) of related 'betaGroups'
+        case betaGroups([String])
+        /// Filter by attribute 'buildAudienceType'
+        case buildAudienceType([BuildAudienceType])
+        /// Filter by attribute 'expired'
+        case expired([String])
+        /// Filter by id(s)
+        case id([String])
+        /// Filter by id(s) of related 'preReleaseVersion'
+        case preReleaseVersion([String])
+        /// Filter by attribute 'preReleaseVersion.platform'
+        case preReleaseVersion_platform([Platform])
+        /// Filter by attribute 'preReleaseVersion.version'
+        case preReleaseVersion_version([String])
+        /// Filter by attribute 'processingState'
+        case processingState([Build.Attributes.ProcessingState])
+        /// Filter by attribute 'usesNonExemptEncryption'
+        case usesNonExemptEncryption([String])
+        /// Filter by attribute 'version'
+        case version([String])
+    }
+
+    /**
+     Attributes, relationships, and IDs to check for existence.
+     */
+    public enum Exist: ExistParameter {
+        /// Filter by attribute 'usesNonExemptEncryption'
+        case usesNonExemptEncryption(Bool)
+    }
+
+    /**
+     Relationship data to include in the response.
+     */
+    public enum Include: String, IncludeParameter, CaseIterable {
+        case app
+        case appEncryptionDeclaration
+        case appStoreVersion
+        case betaAppReviewSubmission
+        case betaBuildLocalizations
+        case betaGroups
+        case buildBetaDetail
+        case buildBundles
+        case buildUpload
+        case icons
+        case individualTesters
+        case preReleaseVersion
+    }
+
+    /**
+     Attributes by which to sort.
+     */
+    public enum Sort: String, SortParameter, CaseIterable {
+        case preReleaseVersionAscending = "preReleaseVersion"
+        case preReleaseVersionDescending = "-preReleaseVersion"
+        case uploadedDateAscending = "uploadedDate"
+        case uploadedDateDescending = "-uploadedDate"
+        case versionAscending = "version"
+        case versionDescending = "-version"
+    }
+
+    /**
+     Number of included related resources to return.
+     */
+    public enum Limit: LimitParameter {
+        /// Maximum number of related betaBuildLocalizations returned (when they are included) - maximum 50
+        case betaBuildLocalizations(Int)
+        /// Maximum number of related betaGroups returned (when they are included) - maximum 50
+        case betaGroups(Int)
+        /// Maximum number of related buildBundles returned (when they are included) - maximum 50
+        case buildBundles(Int)
+        /// Maximum number of related icons returned (when they are included) - maximum 50
+        case icons(Int)
+        /// Maximum number of related individualTesters returned (when they are included) - maximum 50
+        case individualTesters(Int)
+        /// Maximum resources per page - maximum 200
+        case limit(Int)
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppEncryptionDeclarationForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppEncryptionDeclarationForBuildV1.swift
@@ -1,0 +1,68 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Read the app encryption declaration of a build
+     Read an app encryption declaration associated with a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-appEncryptionDeclaration>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getAppEncryptionDeclarationForBuildV1(id: String,
+                                                      fields: [GetAppEncryptionDeclarationForBuildV1.Field]? = nil) -> Request<AppEncryptionDeclarationWithoutIncludesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/appEncryptionDeclaration",
+            method: .get,
+            parameters: .init(fields: fields))
+    }
+}
+
+public enum GetAppEncryptionDeclarationForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type appEncryptionDeclarations
+        case appEncryptionDeclarations([AppEncryptionDeclarations])
+
+        public enum AppEncryptionDeclarations: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appDescription
+            case appEncryptionDeclarationDocument
+            case appEncryptionDeclarationState
+            case availableOnFrenchStore
+            case builds
+            case codeValue
+            case containsProprietaryCryptography
+            case containsThirdPartyCryptography
+            case createdDate
+            case documentName
+            case documentType
+            case documentUrl
+            case exempt
+            case platform
+            case uploadedDate
+            case usesEncryption
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppEncryptionDeclarations(rawValue: string) {
+                    self = value
+                } else if let value = AppEncryptionDeclarations(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppEncryptionDeclarations value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppEncryptionDeclarationIdsForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppEncryptionDeclarationIdsForBuildV1.swift
@@ -1,0 +1,20 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Get the app encryption declaration id for a build
+     Get the beta app encryption declaration resource ID associated with a build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-appEncryptionDeclaration>
+
+     - Parameter id: The id of the requested resource
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getAppEncryptionDeclarationIdsForBuildV1(id: String) -> Request<BuildAppEncryptionDeclarationLinkageResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/appEncryptionDeclaration",
+            method: .get)
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppForBuildV1.swift
@@ -1,0 +1,106 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Read the app information of a build
+     Get the app information for a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-app>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getAppForBuildV1(id: String,
+                                 fields: [GetAppForBuildV1.Field]? = nil) -> Request<AppWithoutIncludesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/app",
+            method: .get,
+            parameters: .init(fields: fields))
+    }
+}
+
+public enum GetAppForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type apps
+        case apps([Apps])
+
+        public enum Apps: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case accessibilityDeclarations
+            case accessibilityUrl
+            case alternativeDistributionKey
+            case analyticsReportRequests
+            case androidToIosAppMappingDetails
+            case appAvailabilityV2
+            case appClips
+            case appCustomProductPages
+            case appEncryptionDeclarations
+            case appEvents
+            case appInfos
+            case appPricePoints
+            case appPriceSchedule
+            case appStoreIcon
+            case appStoreVersionExperimentsV2
+            case appStoreVersions
+            case appTags
+            case backgroundAssets
+            case betaAppLocalizations
+            case betaAppReviewDetail
+            case betaFeedbackCrashSubmissions
+            case betaFeedbackScreenshotSubmissions
+            case betaGroups
+            case betaLicenseAgreement
+            case betaTesters
+            case buildUploads
+            case builds
+            case bundleId
+            case ciProduct
+            case contentRightsDeclaration
+            case customerReviewSummarizations
+            case customerReviews
+            case endUserLicenseAgreement
+            case gameCenterDetail
+            case gameCenterEnabledVersions
+            case inAppPurchases
+            case inAppPurchasesV2
+            case isOrEverWasMadeForKids
+            case marketplaceSearchDetail
+            case name
+            case perfPowerMetrics
+            case preReleaseVersions
+            case primaryLocale
+            case promotedPurchases
+            case reviewSubmissions
+            case searchKeywords
+            case sku
+            case streamlinedPurchasingEnabled
+            case subscriptionGracePeriod
+            case subscriptionGroups
+            case subscriptionStatusUrl
+            case subscriptionStatusUrlForSandbox
+            case subscriptionStatusUrlVersion
+            case subscriptionStatusUrlVersionForSandbox
+            case webhooks
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Apps(rawValue: string) {
+                    self = value
+                } else if let value = Apps(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Apps value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppIdsForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppIdsForBuildV1.swift
@@ -1,0 +1,20 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Read the app id of a build
+     Get the app ID for a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-app>
+
+     - Parameter id: The id of the requested resource
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getAppIdsForBuildV1(id: String) -> Request<BuildAppLinkageResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/app",
+            method: .get)
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppStoreVersionForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppStoreVersionForBuildV1.swift
@@ -1,0 +1,467 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Read the app store version information of a build
+     Get the App Store version of a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-appStoreVersion>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Parameter includes: Relationship data to include in the response
+     - Parameter limits: Number of resources to return
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getAppStoreVersionForBuildV1(id: String,
+                                             fields: [GetAppStoreVersionForBuildV1.Field]? = nil,
+                                             includes: [GetAppStoreVersionForBuildV1.Include]? = nil,
+                                             limits: [GetAppStoreVersionForBuildV1.Limit]? = nil) -> Request<AppStoreVersionResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/appStoreVersion",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                includes: includes,
+                limits: limits))
+    }
+}
+
+public enum GetAppStoreVersionForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type alternativeDistributionPackages
+        case alternativeDistributionPackages([AlternativeDistributionPackages])
+        /// The fields to include for returned resources of type appClipDefaultExperiences
+        case appClipDefaultExperiences([AppClipDefaultExperiences])
+        /// The fields to include for returned resources of type appStoreReviewDetails
+        case appStoreReviewDetails([AppStoreReviewDetails])
+        /// The fields to include for returned resources of type appStoreVersionExperiments
+        case appStoreVersionExperiments([AppStoreVersionExperiments])
+        /// The fields to include for returned resources of type appStoreVersionLocalizations
+        case appStoreVersionLocalizations([AppStoreVersionLocalizations])
+        /// The fields to include for returned resources of type appStoreVersionPhasedReleases
+        case appStoreVersionPhasedReleases([AppStoreVersionPhasedReleases])
+        /// The fields to include for returned resources of type appStoreVersionSubmissions
+        case appStoreVersionSubmissions([AppStoreVersionSubmissions])
+        /// The fields to include for returned resources of type appStoreVersions
+        case appStoreVersions([AppStoreVersions])
+        /// The fields to include for returned resources of type apps
+        case apps([Apps])
+        /// The fields to include for returned resources of type builds
+        case builds([Builds])
+        /// The fields to include for returned resources of type gameCenterAppVersions
+        case gameCenterAppVersions([GameCenterAppVersions])
+        /// The fields to include for returned resources of type routingAppCoverages
+        case routingAppCoverages([RoutingAppCoverages])
+
+        public enum AlternativeDistributionPackages: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case sourceFileChecksum
+            case versions
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AlternativeDistributionPackages(rawValue: string) {
+                    self = value
+                } else if let value = AlternativeDistributionPackages(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AlternativeDistributionPackages value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppClipDefaultExperiences: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case action
+            case appClip
+            case appClipAppStoreReviewDetail
+            case appClipDefaultExperienceLocalizations
+            case releaseWithAppStoreVersion
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppClipDefaultExperiences(rawValue: string) {
+                    self = value
+                } else if let value = AppClipDefaultExperiences(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppClipDefaultExperiences value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreReviewDetails: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appStoreReviewAttachments
+            case appStoreVersion
+            case contactEmail
+            case contactFirstName
+            case contactLastName
+            case contactPhone
+            case demoAccountName
+            case demoAccountPassword
+            case demoAccountRequired
+            case notes
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreReviewDetails(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreReviewDetails(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreReviewDetails value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreVersionExperiments: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appStoreVersion
+            case appStoreVersionExperimentTreatments
+            case controlVersions
+            case endDate
+            case latestControlVersion
+            case name
+            case platform
+            case reviewRequired
+            case startDate
+            case state
+            case trafficProportion
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreVersionExperiments(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreVersionExperiments(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreVersionExperiments value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreVersionLocalizations: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appPreviewSets
+            case appScreenshotSets
+            case appStoreVersion
+            case description
+            case keywords
+            case locale
+            case marketingUrl
+            case promotionalText
+            case searchKeywords
+            case supportUrl
+            case whatsNew
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreVersionLocalizations(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreVersionLocalizations(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreVersionLocalizations value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreVersionPhasedReleases: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case currentDayNumber
+            case phasedReleaseState
+            case startDate
+            case totalPauseDuration
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreVersionPhasedReleases(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreVersionPhasedReleases(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreVersionPhasedReleases value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreVersionSubmissions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appStoreVersion
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreVersionSubmissions(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreVersionSubmissions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreVersionSubmissions value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum AppStoreVersions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case alternativeDistributionPackage
+            case app
+            case appClipDefaultExperience
+            case appStoreReviewDetail
+            case appStoreState
+            case appStoreVersionExperiments
+            case appStoreVersionExperimentsV2
+            case appStoreVersionLocalizations
+            case appStoreVersionPhasedRelease
+            case appStoreVersionSubmission
+            case appVersionState
+            case build
+            case copyright
+            case createdDate
+            case customerReviews
+            case downloadable
+            case earliestReleaseDate
+            case gameCenterAppVersion
+            case platform
+            case releaseType
+            case reviewType
+            case routingAppCoverage
+            case usesIdfa
+            case versionString
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = AppStoreVersions(rawValue: string) {
+                    self = value
+                } else if let value = AppStoreVersions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid AppStoreVersions value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Apps: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case accessibilityDeclarations
+            case accessibilityUrl
+            case alternativeDistributionKey
+            case analyticsReportRequests
+            case androidToIosAppMappingDetails
+            case appAvailabilityV2
+            case appClips
+            case appCustomProductPages
+            case appEncryptionDeclarations
+            case appEvents
+            case appInfos
+            case appPricePoints
+            case appPriceSchedule
+            case appStoreIcon
+            case appStoreVersionExperimentsV2
+            case appStoreVersions
+            case appTags
+            case backgroundAssets
+            case betaAppLocalizations
+            case betaAppReviewDetail
+            case betaFeedbackCrashSubmissions
+            case betaFeedbackScreenshotSubmissions
+            case betaGroups
+            case betaLicenseAgreement
+            case betaTesters
+            case buildUploads
+            case builds
+            case bundleId
+            case ciProduct
+            case contentRightsDeclaration
+            case customerReviewSummarizations
+            case customerReviews
+            case endUserLicenseAgreement
+            case gameCenterDetail
+            case gameCenterEnabledVersions
+            case inAppPurchases
+            case inAppPurchasesV2
+            case isOrEverWasMadeForKids
+            case marketplaceSearchDetail
+            case name
+            case perfPowerMetrics
+            case preReleaseVersions
+            case primaryLocale
+            case promotedPurchases
+            case reviewSubmissions
+            case searchKeywords
+            case sku
+            case streamlinedPurchasingEnabled
+            case subscriptionGracePeriod
+            case subscriptionGroups
+            case subscriptionStatusUrl
+            case subscriptionStatusUrlForSandbox
+            case subscriptionStatusUrlVersion
+            case subscriptionStatusUrlVersionForSandbox
+            case webhooks
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Apps(rawValue: string) {
+                    self = value
+                } else if let value = Apps(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Apps value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Builds: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appEncryptionDeclaration
+            case appStoreVersion
+            case betaAppReviewSubmission
+            case betaBuildLocalizations
+            case betaGroups
+            case buildAudienceType
+            case buildBetaDetail
+            case buildBundles
+            case buildUpload
+            case computedMinMacOsVersion
+            case computedMinVisionOsVersion
+            case diagnosticSignatures
+            case expirationDate
+            case expired
+            case iconAssetToken
+            case icons
+            case individualTesters
+            case lsMinimumSystemVersion
+            case minOsVersion
+            case perfPowerMetrics
+            case preReleaseVersion
+            case processingState
+            case uploadedDate
+            case usesNonExemptEncryption
+            case version
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Builds(rawValue: string) {
+                    self = value
+                } else if let value = Builds(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Builds value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum GameCenterAppVersions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appStoreVersion
+            case compatibilityVersions
+            case enabled
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = GameCenterAppVersions(rawValue: string) {
+                    self = value
+                } else if let value = GameCenterAppVersions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid GameCenterAppVersions value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum RoutingAppCoverages: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appStoreVersion
+            case assetDeliveryState
+            case fileName
+            case fileSize
+            case sourceFileChecksum
+            case uploadOperations
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = RoutingAppCoverages(rawValue: string) {
+                    self = value
+                } else if let value = RoutingAppCoverages(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid RoutingAppCoverages value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     Relationship data to include in the response.
+     */
+    public enum Include: String, IncludeParameter, CaseIterable {
+        case alternativeDistributionPackage
+        case app
+        case appClipDefaultExperience
+        case appStoreReviewDetail
+        case appStoreVersionExperiments
+        case appStoreVersionExperimentsV2
+        case appStoreVersionLocalizations
+        case appStoreVersionPhasedRelease
+        case appStoreVersionSubmission
+        case build
+        case gameCenterAppVersion
+        case routingAppCoverage
+    }
+
+    /**
+     Number of included related resources to return.
+     */
+    public enum Limit: LimitParameter {
+        /// Maximum number of related appStoreVersionExperiments returned (when they are included) - maximum 50
+        case appStoreVersionExperiments(Int)
+        /// Maximum number of related appStoreVersionExperimentsV2 returned (when they are included) - maximum 50
+        case appStoreVersionExperimentsV2(Int)
+        /// Maximum number of related appStoreVersionLocalizations returned (when they are included) - maximum 50
+        case appStoreVersionLocalizations(Int)
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppStoreVersionIdsForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/GetAppStoreVersionIdsForBuildV1.swift
@@ -1,0 +1,19 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Get the App Store version ID for a build
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-appStoreVersion>
+
+     - Parameter id: The id of the requested resource
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getAppStoreVersionIdsForBuildV1(id: String) -> Request<BuildAppStoreVersionLinkageResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/appStoreVersion",
+            method: .get)
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/ListIconIdsForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/ListIconIdsForBuildV1.swift
@@ -1,0 +1,22 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # List icon IDs for a build
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-icons>
+
+     - Parameter id: The id of the requested resource
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listIconIdsForBuildV1(id: String,
+                                      limit: Int? = nil) -> Request<BuildIconsLinkagesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/icons",
+            method: .get,
+            parameters: .init(limit: limit))
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/ListIconsForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/ListIconsForBuildV1.swift
@@ -1,0 +1,59 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # List all icons for a build
+     List all the icons for various platforms delivered with a build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-icons>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listIconsForBuildV1(id: String,
+                                    fields: [ListIconsForBuildV1.Field]? = nil,
+                                    limit: Int? = nil) -> Request<BuildIconsWithoutIncludesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/icons",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                limit: limit))
+    }
+}
+
+public enum ListIconsForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type buildIcons
+        case buildIcons([BuildIcons])
+
+        public enum BuildIcons: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case iconAsset
+            case iconType
+            case masked
+            case name
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildIcons(rawValue: string) {
+                    self = value
+                } else if let value = BuildIcons(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildIcons value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/Relationships/UpdateAppEncryptionDeclarationForBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/Relationships/UpdateAppEncryptionDeclarationForBuildV1.swift
@@ -1,0 +1,24 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+import BagbutikModelsShared
+
+public extension Request {
+    /**
+     # Assign the app encryption declaration for a build
+     Assign an app encryption declaration to a build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/patch-v1-builds-_id_-relationships-appEncryptionDeclaration>
+
+     - Parameter id: The id of the requested resource
+     - Parameter requestBody: Related linkage
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func updateAppEncryptionDeclarationForBuildV1(id: String,
+                                                         requestBody: BuildAppEncryptionDeclarationLinkageRequest) -> Request<EmptyResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/appEncryptionDeclaration",
+            method: .patch,
+            requestBody: requestBody)
+    }
+}

--- a/Sources/BagbutikAppStore/Endpoints/Build/UpdateBuildV1.swift
+++ b/Sources/BagbutikAppStore/Endpoints/Build/UpdateBuildV1.swift
@@ -1,0 +1,23 @@
+import BagbutikCore
+import BagbutikAppStoreModels
+
+public extension Request {
+    /**
+     # Modify a build
+     Expire a build or change its encryption exemption setting.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/patch-v1-builds-_id_>
+
+     - Parameter id: The id of the requested resource
+     - Parameter requestBody: Build representation
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func updateBuildV1(id: String,
+                              requestBody: BuildUpdateRequest) -> Request<BuildResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)",
+            method: .patch,
+            requestBody: requestBody)
+    }
+}

--- a/Sources/BagbutikReporting/Endpoints/Build/Relationships/ListDiagnosticSignatureIdsForBuildV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/Build/Relationships/ListDiagnosticSignatureIdsForBuildV1.swift
@@ -1,0 +1,22 @@
+import BagbutikCore
+import BagbutikReportingModels
+
+public extension Request {
+    /**
+     # List diagnostic signature IDs for a build
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-diagnosticSignatures>
+
+     - Parameter id: The id of the requested resource
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listDiagnosticSignatureIdsForBuildV1(id: String,
+                                                     limit: Int? = nil) -> Request<BuildDiagnosticSignaturesLinkagesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/diagnosticSignatures",
+            method: .get,
+            parameters: .init(limit: limit))
+    }
+}

--- a/Sources/BagbutikReporting/Endpoints/Build/Relationships/ListDiagnosticSignaturesForBuildV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/Build/Relationships/ListDiagnosticSignaturesForBuildV1.swift
@@ -1,0 +1,94 @@
+import BagbutikCore
+import BagbutikReportingModels
+
+public extension Request {
+    /**
+     # List all diagnostic signatures for a build
+     List the aggregate backtrace signatures captured for a specific build.
+
+     The example below requests the top two weighted disk write diagnostic signatures. The example response returns two signatures that are responsible for 85% and 7% of disk writes.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-diagnosticSignatures>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Parameter filters: Attributes, relationships, and IDs by which to filter
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listDiagnosticSignaturesForBuildV1(id: String,
+                                                   fields: [ListDiagnosticSignaturesForBuildV1.Field]? = nil,
+                                                   filters: [ListDiagnosticSignaturesForBuildV1.Filter]? = nil,
+                                                   limit: Int? = nil) -> Request<DiagnosticSignaturesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/diagnosticSignatures",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                filters: filters,
+                limit: limit))
+    }
+}
+
+public enum ListDiagnosticSignaturesForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type diagnosticSignatures
+        case diagnosticSignatures([DiagnosticSignatures])
+
+        public enum DiagnosticSignatures: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case diagnosticType
+            case insight
+            case logs
+            case signature
+            case weight
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = DiagnosticSignatures(rawValue: string) {
+                    self = value
+                } else if let value = DiagnosticSignatures(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid DiagnosticSignatures value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     Attributes, relationships, and IDs by which to filter.
+     */
+    public enum Filter: FilterParameter {
+        /// Filter by attribute 'diagnosticType'
+        case diagnosticType([DiagnosticType])
+
+        public enum DiagnosticType: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case diskWrites = "DISK_WRITES"
+            case hangs = "HANGS"
+            case launches = "LAUNCHES"
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = DiagnosticType(rawValue: string) {
+                    self = value
+                } else if let value = DiagnosticType(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid DiagnosticType value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikReporting/Endpoints/Build/Relationships/ListPerfPowerMetricsForBuildV1.swift
+++ b/Sources/BagbutikReporting/Endpoints/Build/Relationships/ListPerfPowerMetricsForBuildV1.swift
@@ -1,0 +1,85 @@
+import BagbutikCore
+import BagbutikModelsShared
+import BagbutikReportingModels
+
+public extension Request {
+    /**
+     # Get power and performance metrics for a build
+     Get the performance and power metrics data for a specific build.
+
+     The example below requests iOS animation metrics on all iPads for a specific build. To get the metrics for all of the most-recent app versions instead, use the [Get power and performance metrics for an app](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-apps-_id_-perfpowermetrics) endpoint.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-perfPowerMetrics>
+
+     - Parameter id: The id of the requested resource
+     - Parameter filters: Attributes, relationships, and IDs by which to filter
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listPerfPowerMetricsForBuildV1(id: String,
+                                               filters: [ListPerfPowerMetricsForBuildV1.Filter]? = nil) -> Request<XcodeMetrics, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/perfPowerMetrics",
+            method: .get,
+            parameters: .init(filters: filters))
+    }
+}
+
+public enum ListPerfPowerMetricsForBuildV1 {
+    /**
+     Attributes, relationships, and IDs by which to filter.
+     */
+    public enum Filter: FilterParameter {
+        /// Filter by attribute 'deviceType'
+        case deviceType([String])
+        /// Filter by attribute 'metricType'
+        case metricType([MetricType])
+        /// Filter by attribute 'platform'
+        case platform([Platform])
+
+        public enum MetricType: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case animation = "ANIMATION"
+            case battery = "BATTERY"
+            case disk = "DISK"
+            case hang = "HANG"
+            case launch = "LAUNCH"
+            case memory = "MEMORY"
+            case storage = "STORAGE"
+            case termination = "TERMINATION"
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = MetricType(rawValue: string) {
+                    self = value
+                } else if let value = MetricType(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid MetricType value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Platform: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case iOS = "IOS"
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Platform(rawValue: string) {
+                    self = value
+                } else if let value = Platform(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Platform value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/CreateBetaGroupsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/CreateBetaGroupsForBuildV1.swift
@@ -1,0 +1,24 @@
+import BagbutikCore
+import BagbutikModelsShared
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Add access for beta groups to a build
+     Add or create a beta group to a build to enable testing.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/post-v1-builds-_id_-relationships-betaGroups>
+
+     - Parameter id: The id of the requested resource
+     - Parameter requestBody: List of related linkages
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func createBetaGroupsForBuildV1(id: String,
+                                           requestBody: BuildBetaGroupsLinkagesRequest) -> Request<EmptyResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/betaGroups",
+            method: .post,
+            requestBody: requestBody)
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/CreateIndividualTestersForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/CreateIndividualTestersForBuildV1.swift
@@ -1,0 +1,24 @@
+import BagbutikCore
+import BagbutikModelsShared
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Assign individual testers to a build
+     Enable a beta tester who is not a part of a beta group to test a build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/post-v1-builds-_id_-relationships-individualTesters>
+
+     - Parameter id: The id of the requested resource
+     - Parameter requestBody: List of related linkages
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func createIndividualTestersForBuildV1(id: String,
+                                                  requestBody: BuildIndividualTestersLinkagesRequest) -> Request<EmptyResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/individualTesters",
+            method: .post,
+            requestBody: requestBody)
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/DeleteBetaGroupsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/DeleteBetaGroupsForBuildV1.swift
@@ -1,0 +1,24 @@
+import BagbutikCore
+import BagbutikModelsShared
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Remove access for beta groups to a build
+     Remove access to a specific build for all beta testers in one or more beta groups.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/delete-v1-builds-_id_-relationships-betaGroups>
+
+     - Parameter id: The id of the requested resource
+     - Parameter requestBody: List of related linkages
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func deleteBetaGroupsForBuildV1(id: String,
+                                           requestBody: BuildBetaGroupsLinkagesRequest) -> Request<EmptyResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/betaGroups",
+            method: .delete,
+            requestBody: requestBody)
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/DeleteIndividualTestersForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/DeleteIndividualTestersForBuildV1.swift
@@ -1,0 +1,24 @@
+import BagbutikCore
+import BagbutikModelsShared
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Remove individual testers from a build
+     Remove access to test a specific build from one or more individually assigned testers.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/delete-v1-builds-_id_-relationships-individualTesters>
+
+     - Parameter id: The id of the requested resource
+     - Parameter requestBody: List of related linkages
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func deleteIndividualTestersForBuildV1(id: String,
+                                                  requestBody: BuildIndividualTestersLinkagesRequest) -> Request<EmptyResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/individualTesters",
+            method: .delete,
+            requestBody: requestBody)
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBetaAppReviewSubmissionForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBetaAppReviewSubmissionForBuildV1.swift
@@ -1,0 +1,54 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Read the beta app review submission of a build
+     Get the beta app review submission status for a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-betaAppReviewSubmission>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getBetaAppReviewSubmissionForBuildV1(id: String,
+                                                     fields: [GetBetaAppReviewSubmissionForBuildV1.Field]? = nil) -> Request<BetaAppReviewSubmissionWithoutIncludesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/betaAppReviewSubmission",
+            method: .get,
+            parameters: .init(fields: fields))
+    }
+}
+
+public enum GetBetaAppReviewSubmissionForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type betaAppReviewSubmissions
+        case betaAppReviewSubmissions([BetaAppReviewSubmissions])
+
+        public enum BetaAppReviewSubmissions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case betaReviewState
+            case build
+            case submittedDate
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaAppReviewSubmissions(rawValue: string) {
+                    self = value
+                } else if let value = BetaAppReviewSubmissions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaAppReviewSubmissions value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBetaAppReviewSubmissionIdsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBetaAppReviewSubmissionIdsForBuildV1.swift
@@ -1,0 +1,19 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Get the beta app review submission ID for a build
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-betaAppReviewSubmission>
+
+     - Parameter id: The id of the requested resource
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getBetaAppReviewSubmissionIdsForBuildV1(id: String) -> Request<BuildBetaAppReviewSubmissionLinkageResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/betaAppReviewSubmission",
+            method: .get)
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBuildBetaDetailForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBuildBetaDetailForBuildV1.swift
@@ -1,0 +1,112 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Read the build beta details information of a build
+     Get the beta test details for a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-buildBetaDetail>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Parameter includes: Relationship data to include in the response
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getBuildBetaDetailForBuildV1(id: String,
+                                             fields: [GetBuildBetaDetailForBuildV1.Field]? = nil,
+                                             includes: [GetBuildBetaDetailForBuildV1.Include]? = nil) -> Request<BuildBetaDetailResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/buildBetaDetail",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                includes: includes))
+    }
+}
+
+public enum GetBuildBetaDetailForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type buildBetaDetails
+        case buildBetaDetails([BuildBetaDetails])
+        /// The fields to include for returned resources of type builds
+        case builds([Builds])
+
+        public enum BuildBetaDetails: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case autoNotifyEnabled
+            case build
+            case externalBuildState
+            case internalBuildState
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BuildBetaDetails(rawValue: string) {
+                    self = value
+                } else if let value = BuildBetaDetails(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BuildBetaDetails value: \(string)"
+                    )
+                }
+            }
+        }
+
+        public enum Builds: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case appEncryptionDeclaration
+            case appStoreVersion
+            case betaAppReviewSubmission
+            case betaBuildLocalizations
+            case betaGroups
+            case buildAudienceType
+            case buildBetaDetail
+            case buildBundles
+            case buildUpload
+            case computedMinMacOsVersion
+            case computedMinVisionOsVersion
+            case diagnosticSignatures
+            case expirationDate
+            case expired
+            case iconAssetToken
+            case icons
+            case individualTesters
+            case lsMinimumSystemVersion
+            case minOsVersion
+            case perfPowerMetrics
+            case preReleaseVersion
+            case processingState
+            case uploadedDate
+            case usesNonExemptEncryption
+            case version
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = Builds(rawValue: string) {
+                    self = value
+                } else if let value = Builds(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid Builds value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     Relationship data to include in the response.
+     */
+    public enum Include: String, IncludeParameter, CaseIterable {
+        case build
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBuildBetaDetailIdsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetBuildBetaDetailIdsForBuildV1.swift
@@ -1,0 +1,19 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Get the build beta detail ID for a build
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-buildBetaDetail>
+
+     - Parameter id: The id of the requested resource
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getBuildBetaDetailIdsForBuildV1(id: String) -> Request<BuildBuildBetaDetailLinkageResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/buildBetaDetail",
+            method: .get)
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetMetricsForBetaBuildUsageInBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetMetricsForBetaBuildUsageInBuildV1.swift
@@ -1,0 +1,23 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Read Usage Metrics for a Beta Build
+     Get usage metrics for a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-metrics-betaBuildUsages>
+
+     - Parameter id: The id of the requested resource
+     - Parameter limit: Maximum number of groups to return per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getMetricsForBetaBuildUsageInBuildV1(id: String,
+                                                     limit: Int? = nil) -> Request<BetaBuildUsagesV1MetricResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/metrics/betaBuildUsages",
+            method: .get,
+            parameters: .init(limit: limit))
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetPreReleaseVersionForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetPreReleaseVersionForBuildV1.swift
@@ -1,0 +1,55 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Read the prerelease version of a build
+     Get the prerelease version for a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-preReleaseVersion>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getPreReleaseVersionForBuildV1(id: String,
+                                               fields: [GetPreReleaseVersionForBuildV1.Field]? = nil) -> Request<PrereleaseVersionWithoutIncludesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/preReleaseVersion",
+            method: .get,
+            parameters: .init(fields: fields))
+    }
+}
+
+public enum GetPreReleaseVersionForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type preReleaseVersions
+        case preReleaseVersions([PreReleaseVersions])
+
+        public enum PreReleaseVersions: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case app
+            case builds
+            case platform
+            case version
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = PreReleaseVersions(rawValue: string) {
+                    self = value
+                } else if let value = PreReleaseVersions(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid PreReleaseVersions value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetPreReleaseVersionIdsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/GetPreReleaseVersionIdsForBuildV1.swift
@@ -1,0 +1,19 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Get the prerelease version ID for a build
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-preReleaseVersion>
+
+     - Parameter id: The id of the requested resource
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func getPreReleaseVersionIdsForBuildV1(id: String) -> Request<BuildPreReleaseVersionLinkageResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/preReleaseVersion",
+            method: .get)
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListBetaBuildLocalizationIdsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListBetaBuildLocalizationIdsForBuildV1.swift
@@ -1,0 +1,22 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # List beta build localization IDs for a build
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-betaBuildLocalizations>
+
+     - Parameter id: The id of the requested resource
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listBetaBuildLocalizationIdsForBuildV1(id: String,
+                                                       limit: Int? = nil) -> Request<BuildBetaBuildLocalizationsLinkagesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/betaBuildLocalizations",
+            method: .get,
+            parameters: .init(limit: limit))
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListBetaBuildLocalizationsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListBetaBuildLocalizationsForBuildV1.swift
@@ -1,0 +1,58 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # List all beta build localizations of a build
+     Get a list of localized beta test information for a specific build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-betaBuildLocalizations>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listBetaBuildLocalizationsForBuildV1(id: String,
+                                                     fields: [ListBetaBuildLocalizationsForBuildV1.Field]? = nil,
+                                                     limit: Int? = nil) -> Request<BetaBuildLocalizationsWithoutIncludesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/betaBuildLocalizations",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                limit: limit))
+    }
+}
+
+public enum ListBetaBuildLocalizationsForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type betaBuildLocalizations
+        case betaBuildLocalizations([BetaBuildLocalizations])
+
+        public enum BetaBuildLocalizations: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case build
+            case locale
+            case whatsNew
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaBuildLocalizations(rawValue: string) {
+                    self = value
+                } else if let value = BetaBuildLocalizations(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaBuildLocalizations value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListIndividualTesterIdsForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListIndividualTesterIdsForBuildV1.swift
@@ -1,0 +1,23 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # Get all resource ids of individual testers for a build
+     Get a list of resource IDs of individual testers associated with a build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-individualTesters>
+
+     - Parameter id: The id of the requested resource
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listIndividualTesterIdsForBuildV1(id: String,
+                                                  limit: Int? = nil) -> Request<BuildIndividualTestersLinkagesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/relationships/individualTesters",
+            method: .get,
+            parameters: .init(limit: limit))
+    }
+}

--- a/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListIndividualTestersForBuildV1.swift
+++ b/Sources/BagbutikTestFlight/Endpoints/Build/Relationships/ListIndividualTestersForBuildV1.swift
@@ -1,0 +1,64 @@
+import BagbutikCore
+import BagbutikTestFlightModels
+
+public extension Request {
+    /**
+     # List all individual testers for a build
+     Get a list of beta testers individually assigned to a build.
+
+     Full documentation:
+     <https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-individualTesters>
+
+     - Parameter id: The id of the requested resource
+     - Parameter fields: Fields to return for included related types
+     - Parameter limit: Maximum resources per page - maximum 200
+     - Returns: A ``Request`` to send to an instance of ``BagbutikService``
+     */
+    static func listIndividualTestersForBuildV1(id: String,
+                                                fields: [ListIndividualTestersForBuildV1.Field]? = nil,
+                                                limit: Int? = nil) -> Request<BetaTestersWithoutIncludesResponse, ErrorResponse> {
+        .init(
+            path: "/v1/builds/\(id)/individualTesters",
+            method: .get,
+            parameters: .init(
+                fields: fields,
+                limit: limit))
+    }
+}
+
+public enum ListIndividualTestersForBuildV1 {
+    /**
+     Fields to return for included related types.
+     */
+    public enum Field: FieldParameter {
+        /// The fields to include for returned resources of type betaTesters
+        case betaTesters([BetaTesters])
+
+        public enum BetaTesters: String, Sendable, ParameterValue, Codable, CaseIterable {
+            case appDevices
+            case apps
+            case betaGroups
+            case builds
+            case email
+            case firstName
+            case inviteType
+            case lastName
+            case state
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                if let value = BetaTesters(rawValue: string) {
+                    self = value
+                } else if let value = BetaTesters(rawValue: string.uppercased()) {
+                    self = value
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid BetaTesters value: \(string)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -615,8 +615,9 @@ let customerReviews = Request<CustomerReviewsResponse, ErrorResponse>.listCustom
 let subscriptions = Request<SubscriptionsResponse, ErrorResponse>.listSubscriptionsForSubscriptionGroupV1(
     id: "subscription-group-1"
 )
+let build = Request<BuildResponse, ErrorResponse>.getBuildV1(id: "build-1")
 
-print(customerReviews.path, subscriptions.path)
+print(customerReviews.path, subscriptions.path, build.path)
 SOURCE_EOF
 
   cat > "$INTEGRATION_DIR/BagbutikGameCenterBinaryClient/Package.swift" <<'PACKAGE_EOF'
@@ -783,8 +784,11 @@ let request = Request<Gzip, ErrorResponse>.getSalesReportsV1(filters: [
     .reportSubType([.summary]),
     .frequency([.daily]),
 ])
+let diagnosticSignatures = Request<DiagnosticSignaturesResponse, ErrorResponse>.listDiagnosticSignaturesForBuildV1(
+    id: "build-1"
+)
 
-print(request.path)
+print(request.path, diagnosticSignatures.path)
 SOURCE_EOF
 
   cat > "$INTEGRATION_DIR/BagbutikTestFlightBinaryClient/Package.swift" <<'PACKAGE_EOF'
@@ -825,8 +829,9 @@ let request = Request<BetaFeedbackCrashSubmissionResponse, ErrorResponse>.getBet
     id: "submission-1",
     includes: [.build, .tester]
 )
+let buildBetaDetail = Request<BuildBetaDetailResponse, ErrorResponse>.getBuildBetaDetailForBuildV1(id: "build-1")
 
-print(request.path)
+print(request.path, buildBetaDetail.path)
 SOURCE_EOF
 
   cat > "$INTEGRATION_DIR/BagbutikUsersBinaryClient/Package.swift" <<'PACKAGE_EOF'


### PR DESCRIPTION
## Summary

Restores the 30 generated Build endpoint APIs missing from the v24 source package and the 24.0.0 pre3 binary artifacts.

The cause was the unanchored `build` entry in `.gitignore`. On a case insensitive macOS checkout, it ignored every generated `Endpoints/Build` directory. The rule is now anchored as `/build`.

The binary integration clients now compile representative Build APIs from App Store, TestFlight, and Reporting.

## Validation

- `swift run --disable-sandbox --package-path Tools bagbutik-cli generate --spec-path 'openapi.oas (2).json' --output-path Sources --documentation-path Documentation`
- `swift test --disable-sandbox` (93 tests passed)
- `bash -n scripts/build-xcframework.sh`
- `swift package dump-package --disable-sandbox`

A new binary prerelease is required after this merges because 24.0.0 pre3 was built from the affected source tag.