### PR TITLE
Clarify version 24 package migration

### DIFF
--- a/Documentation/Bagbutik 24.0 Migration Guide.md
+++ b/Documentation/Bagbutik 24.0 Migration Guide.md
@@ -4,16 +4,22 @@ Bagbutik 24 introduces modular products and clean Swift module names. This is an
 
 ## Select the products your target uses
 
-For the smallest source build, add `BagbutikCore` and each product needed by the target. For example, an app that manages bundle IDs selects `BagbutikCore` and `BagbutikProvisioning`.
+For the smallest source build, add each public API product needed by the target. Each product includes `BagbutikCore` and its required generated model modules. For example, an app that manages bundle IDs selects `BagbutikProvisioning`.
 
 ```swift
 .target(
     name: "AppStoreClient",
     dependencies: [
-        .product(name: "BagbutikCore", package: "Bagbutik"),
         .product(name: "BagbutikProvisioning", package: "Bagbutik"),
     ]
 )
+```
+
+Import the API product and `BagbutikCore` in Swift source:
+
+```swift
+import BagbutikCore
+import BagbutikProvisioning
 ```
 
 ## Replace product and import names
@@ -21,6 +27,7 @@ For the smallest source build, add `BagbutikCore` and each product needed by the
 | Earlier product and import | Version 24 product and import |
 | --- | --- |
 | `Bagbutik-Core`, `import Bagbutik_Core` | `BagbutikCore`, `import BagbutikCore` |
+| `Bagbutik-Models`, `import Bagbutik_Models` | No single replacement. See generated model imports below. |
 | `Bagbutik-AppStore`, `import Bagbutik_AppStore` | `BagbutikAppStore`, `import BagbutikAppStore` |
 | `Bagbutik-GameCenter`, `import Bagbutik_GameCenter` | `BagbutikGameCenter`, `import BagbutikGameCenter` |
 | `Bagbutik-Marketplaces`, `import Bagbutik_Marketplaces` | `BagbutikMarketplaces`, `import BagbutikMarketplaces` |
@@ -33,7 +40,7 @@ For the smallest source build, add `BagbutikCore` and each product needed by the
 
 ## Generated model imports
 
-`Bagbutik-Models` is removed. Model modules are selected with each public product. Most applications should import `BagbutikCore` and the endpoint product only. When application code directly uses a generated model type that is not exposed through an endpoint, import the matching `Bagbutik<Domain>Models` module.
+The `Bagbutik-Models` product and `import Bagbutik_Models` are removed. There is no single replacement because models are grouped by API domain. Most applications should import `BagbutikCore` and the endpoint product only. When application code directly uses a generated model type that is not exposed through an endpoint, import the matching `Bagbutik<Domain>Models` module.
 
 The source package no longer provides compatibility products for `Bagbutik-Core` or `Bagbutik-Models`. Update all imports and product dependencies before adopting version 24.
 
@@ -45,6 +52,16 @@ import BagbutikProvisioningModels
 
 ## Source and binary distributions
 
-The source and binary distributions expose the same modular product and module names. The source distribution also provides the optional `Bagbutik` umbrella product for consumers who prefer one import over a selective build. The binary distribution does not provide that umbrella product.
+The source and binary distributions expose the same modular product and module names. The source distribution also provides an optional, importable `Bagbutik` umbrella module for consumers who prefer one import over a selective build. The binary distribution does not provide that umbrella module.
 
-Choose one distribution for a target. Adding both would create duplicate Swift module names.
+To switch an existing target to the binary distribution, replace the source package dependency with:
+
+```swift
+.package(
+    name: "Bagbutik",
+    url: "https://github.com/MortenGregersen/Bagbutik-Binary",
+    from: "24.0.0"
+)
+```
+
+Keep the same selected product dependencies and imports. Choose one distribution for a target. Adding both would create duplicate Swift module names.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Then add the required products to your target:
 )
 ```
 
-Select each public product your application uses for the smallest source build. The source package also provides an optional `Bagbutik` umbrella product that imports every API area.
+Select each public product your application uses for the smallest source build. Each product includes the core and generated model targets it requires. The source package also provides an optional `Bagbutik` umbrella product that imports every API area.
 
 #### Available modules
 
@@ -133,15 +133,38 @@ This keeps each endpoint builder lightweight while centralizing authentication, 
 
 ### Using a prebuilt binary package
 
-Bagbutik also provides a prebuilt static XCFramework distribution for projects that prefer not to compile Bagbutik sources. It uses the same public products and imports as the source package. Select the products your app uses, such as `BagbutikProvisioning` or `BagbutikAppStore`. The source only `Bagbutik` umbrella product is not part of the binary distribution.
+Bagbutik also provides a prebuilt static XCFramework distribution for projects that prefer not to compile Bagbutik sources. It uses the same public products and imports as the source package. Select the products your app uses, such as `BagbutikProvisioning` or `BagbutikAppStore`. The source package only `Bagbutik` umbrella product is not part of the binary distribution.
 
-Use either the source package or the binary package in one target. Do not add both because they intentionally expose the same Swift module names. The binary package and its release assets are published separately from the source repository.
+Add the binary package to your `Package.swift` with the explicit package name `Bagbutik`:
+
+```swift
+dependencies: [
+    .package(
+        name: "Bagbutik",
+        url: "https://github.com/MortenGregersen/Bagbutik-Binary",
+        from: "24.0.0"
+    ),
+]
+```
+
+Then use the same product declaration as the source package:
+
+```swift
+.target(
+    name: "Awesome",
+    dependencies: [
+        .product(name: "BagbutikProvisioning", package: "Bagbutik"),
+    ]
+)
+```
+
+Use either the source package or the binary package in one target. Do not add both because they intentionally expose the same Swift module names. To change distribution, replace the package URL while keeping the explicit package name and selected products. The binary package and its release assets are published separately from the source repository.
 
 For version 24 breaking changes, see the [migration guide](Documentation/Bagbutik%2024.0%20Migration%20Guide.md).
 
 ## Maintaining generated code
 
-Most files under `Sources/Bagbutik-*` are generated from Apple's OpenAPI document. The generation pipeline is:
+Most files under `Sources/` are generated from Apple's OpenAPI document. The generation pipeline is:
 
 1. Load and patch the OpenAPI spec.
 2. Fetch Apple documentation as JSON.


### PR DESCRIPTION
## Summary

Completes the version 24 consumer documentation before the architecture branch merges into main.

- Shows how to add the separate Bagbutik Binary package while keeping the package name and product declarations consistent.
- Explains that an endpoint product already includes its required core and model targets.
- Documents the removal of the single Bagbutik Models module and the source package umbrella import.
- Removes the stale generated source folder pattern from the README.

## Validation

- Reviewed against the source package manifest and the Bagbutik Binary package manifest.
- 