### PR TITLE
Add watchOS arm64_32 slices to XCFrameworks

### DIFF
--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -80,6 +80,7 @@ sdk_triples() {
       ;;
     watchos)
       echo "arm64-apple-watchos9.0"
+      echo "arm64_32-apple-watchos9.0"
       ;;
     watchsimulator)
       echo "arm64-apple-watchos9.0-simulator"
@@ -731,24 +732,24 @@ verify_visionos_binary_integration() {
 }
 
 report_watch_sample_size() {
-  local arm64_binary
+  local arm64_32_binary
   local client
   local size
   local stripped_binary
 
   for client in "${BUILD_TARGETS[@]}"; do
-    arm64_binary="$INTEGRATION_DIR/build/$client/arm64-apple-watchos9.0/arm64-apple-watchos/$CONFIGURATION/${client}BinaryClient"
+    arm64_32_binary="$INTEGRATION_DIR/build/$client/arm64_32-apple-watchos9.0/arm64_32-apple-watchos/$CONFIGURATION/${client}BinaryClient"
     stripped_binary="$DIST_DIR/${client}WatchSample"
 
-    if [ ! -f "$arm64_binary" ]; then
+    if [ ! -f "$arm64_32_binary" ]; then
       continue
     fi
 
-    cp "$arm64_binary" "$stripped_binary"
+    cp "$arm64_32_binary" "$stripped_binary"
     xcrun strip -x "$stripped_binary"
 
     size="$(stat -f '%z' "$stripped_binary")"
-    echo "Stripped arm64 $client watch sample executable: $size bytes"
+    echo "Stripped arm64_32 $client watch sample executable: $size bytes"
 
     if [ "$size" -gt 50000000 ]; then
       echo "$client watch sample executable exceeds the 50 MB release gate." >&2


### PR DESCRIPTION
## What changed

* Build an `arm64_32-apple-watchos9.0` device slice alongside the existing `arm64` watchOS slice.
* Run the static watch sample size gate against the physical watch `arm64_32` binary.

## Why

Bagbutik Binary 24.0.0-pre5 omitted `arm64_32` from its watchOS XCFramework slices. AppDabWatch therefore could not resolve Bagbutik modules when targeting a physical Apple Watch, even though the package deployment target remains watchOS 9.

## Impact

The next Bagbutik Binary pre release built from this source will provide a `watchos-arm64_arm64_32` slice, allowing modern watchOS apps to compile against the binary distribution. This does not restore armv7k or watchOS 8 support.

## Validation

* `bash -n scripts/build-xcframework.sh`
* `BAGBUTIK_SDKS=watchos BAGBUTIK_SKIP_ZIP=true ./scripts/build-xcframework.sh`
* Confirmed `BagbutikCore.xcframework` reports both `arm64` and `arm64_32` for watchOS.
* Confirmed all binary consumer fixtures compile for `arm64_32-apple-watchos9.0`.
