### PR TITLE
Fix XCFramework bundle layout

### DIFF
--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -80,6 +80,7 @@ sdk_triples() {
       ;;
     watchos)
       echo "arm64-apple-watchos9.0"
+      echo "arm64_32-apple-watchos9.0"
       ;;
     watchsimulator)
       echo "arm64-apple-watchos9.0-simulator"
@@ -731,24 +732,24 @@ verify_visionos_binary_integration() {
 }
 
 report_watch_sample_size() {
-  local arm64_binary
+  local arm64_32_binary
   local client
   local size
   local stripped_binary
 
   for client in "${BUILD_TARGETS[@]}"; do
-    arm64_binary="$INTEGRATION_DIR/build/$client/arm64-apple-watchos9.0/arm64-apple-watchos/$CONFIGURATION/${client}BinaryClient"
+    arm64_32_binary="$INTEGRATION_DIR/build/$client/arm64_32-apple-watchos9.0/arm64_32-apple-watchos/$CONFIGURATION/${client}BinaryClient"
     stripped_binary="$DIST_DIR/${client}WatchSample"
 
-    if [ ! -f "$arm64_binary" ]; then
+    if [ ! -f "$arm64_32_binary" ]; then
       continue
     fi
 
-    cp "$arm64_binary" "$stripped_binary"
+    cp "$arm64_32_binary" "$stripped_binary"
     xcrun strip -x "$stripped_binary"
 
     size="$(stat -f '%z' "$stripped_binary")"
-    echo "Stripped arm64 $client watch sample executable: $size bytes"
+    echo "Stripped arm64_32 $client watch sample executable: $size bytes"
 
     if [ "$size" -gt 50000000 ]; then
       echo "$client watch sample executable exceeds the 50 MB release gate." >&2

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -293,12 +293,19 @@ combine_sdk_module() {
   xcrun strip -S "$output_directory/lib$module.a"
 
   local framework_directory="$output_directory/$module.framework"
-  local framework_version_directory="$framework_directory/Versions/A"
-  mkdir -p "$framework_version_directory/Modules/$module.swiftmodule" "$framework_version_directory/Resources"
-  mv "$output_directory/lib$module.a" "$framework_version_directory/$module"
+  local framework_contents_directory="$framework_directory"
+  local info_plist_directory="$framework_directory"
+
+  if [ "$sdk" = "macosx" ]; then
+    framework_contents_directory="$framework_directory/Versions/A"
+    info_plist_directory="$framework_contents_directory/Resources"
+  fi
+
+  mkdir -p "$framework_contents_directory/Modules/$module.swiftmodule" "$info_plist_directory"
+  mv "$output_directory/lib$module.a" "$framework_contents_directory/$module"
   cp "$output_directory/Headers/$module.swiftmodule"/*.swiftinterface \
-    "$framework_version_directory/Modules/$module.swiftmodule/"
-  cat > "$framework_version_directory/Resources/Info.plist" <<EOF
+    "$framework_contents_directory/Modules/$module.swiftmodule/"
+  cat > "$info_plist_directory/Info.plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -322,10 +329,13 @@ combine_sdk_module() {
 </dict>
 </plist>
 EOF
-  ln -s A "$framework_directory/Versions/Current"
-  ln -s Versions/Current/$module "$framework_directory/$module"
-  ln -s Versions/Current/Modules "$framework_directory/Modules"
-  ln -s Versions/Current/Resources "$framework_directory/Resources"
+
+  if [ "$sdk" = "macosx" ]; then
+    ln -s A "$framework_directory/Versions/Current"
+    ln -s Versions/Current/$module "$framework_directory/$module"
+    ln -s Versions/Current/Modules "$framework_directory/Modules"
+    ln -s Versions/Current/Resources "$framework_directory/Resources"
+  fi
 }
 
 create_module_xcframework() {
@@ -382,21 +392,19 @@ let package = Package(
         .visionOS(.v1),
     ],
     products: [
+        .library(
+            name: "BagbutikCore",
+            targets: ["BagbutikCore"]
+        ),
 PACKAGE_EOF
 
   for client in "${BUILD_TARGETS[@]}"; do
     cat >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift" <<EOF
         .library(
             name: "$client",
-            targets: [
-EOF
-    while IFS= read -r module; do
-      echo "                \"$module\"," >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift"
-    done < <(client_link_modules "$client")
-    cat >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift" <<'PRODUCT_EOF'
-            ]
+            targets: ["${client}Product"]
         ),
-PRODUCT_EOF
+EOF
   done
 
   cat >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift" <<'TARGETS_EOF'
@@ -405,6 +413,25 @@ PRODUCT_EOF
 TARGETS_EOF
   for module in "${MODULES[@]}"; do
     echo "        .binaryTarget(name: \"$module\", path: \"Artifacts/$module.xcframework\")," >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift"
+  done
+  for client in "${BUILD_TARGETS[@]}"; do
+    mkdir -p "$INTEGRATION_DIR/BagbutikBinaryPackage/Sources/${client}Product"
+    : > "$INTEGRATION_DIR/BagbutikBinaryPackage/Sources/${client}Product/Exports.swift"
+
+    cat >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift" <<EOF
+        .target(
+            name: "${client}Product",
+            dependencies: [
+EOF
+    while IFS= read -r module; do
+      echo "                \"$module\"," >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift"
+      echo "@_exported import $module" >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Sources/${client}Product/Exports.swift"
+    done < <(client_link_modules "$client")
+    echo "public enum ${client}Product {}" >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Sources/${client}Product/Exports.swift"
+    cat >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift" <<'TARGET_EOF'
+            ]
+        ),
+TARGET_EOF
   done
   cat >> "$INTEGRATION_DIR/BagbutikBinaryPackage/Package.swift" <<'PACKAGE_EOF'
     ]


### PR DESCRIPTION
## What changed

Build static XCFrameworks as shallow frameworks on iOS, tvOS, watchOS, and visionOS. Keep the versioned framework layout only for macOS.

The generated binary package now uses explicit aggregate targets that re export every framework required by a domain product. It also exposes `BagbutikCore` as an individual binary product.

## Why

watchOS rejects embedded versioned framework bundles because their `Info.plist` is under `Versions/Current/Resources` rather than at the framework root. The previous binary package product shape also did not express module dependencies to Xcode, which could leave imported model modules unavailable while compiling a consumer.

## Impact

The corrected candidate produces a successful unsigned AppDabWatch archive. Its embedded watch app is 80.03 MiB, with a 29.39 MiB consistently compressed local comparison.

## Validation

* Built and linked all binary package consumer fixtures for `arm64` and `arm64_32` watchOS targets.
* Built and linked the iOS binary package consumer fixtures.
* Created a successful unsigned Release `AppDabWatch` archive using the corrected candidate XCFrameworks.
