### PR TITLE
Remove unnecessary gzip try

### DIFF
--- a/Sources/BagbutikCore/Internal/Data+Gzip.swift
+++ b/Sources/BagbutikCore/Internal/Data+Gzip.swift
@@ -26,7 +26,7 @@ internal extension Data {
             stream.avail_out = uInt(gzipBufferLength)
             decompressed.count += gzipBufferLength
             
-            try decompressed.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) in
+            decompressed.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) in
                 stream.next_out = bytes
                     .bindMemory(to: Bytef.self)
                     .baseAddress?


### PR DESCRIPTION
## Summary

Removes an unnecessary `try` from gzip buffer access.

## Root cause

The mutable buffer access closure does not throw, so the compiler reports the `try` expression as unnecessary.

## Impact

Removes the remaining non deprecation build warning without changing gzip decompression or platform specific zlib imports.

## Validation

`swift build`

`swift test --skip-build --filter GunzipTests`
